### PR TITLE
Add Travis for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ before_script:
   - sh ci/install-ldns.sh
 
 script:
-  - mkdir build
-  - cd build
-  - cmake ..
-  - make
+  - mkdir build && cd build && cmake ..
+  - make all tests
+  - ./tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+---
+os: linux
+dist: xenial
+language: c
+
+addons:
+  apt:
+    packages:
+      - cmake
+      - libssl-dev
+
+before_script:
+  - sh ci/install-libuv.sh
+  - sh ci/install-ldns.sh
+
+script:
+  - mkdir build
+  - cd build
+  - cmake ..
+  - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,28 @@
 ---
-os: linux
-dist: xenial
 language: c
+dist: xenial
 
-addons:
-  apt:
-    packages:
-      - cmake
-      - libssl-dev
+matrix:
+  include:
+    - os: linux
+      addons:
+        apt:
+          packages:
+            - cmake
+            - libssl-dev
+    - os: osx
+      addons:
+        homebrew:
+          update: true
+          packages:
+            - cmake
+            - libuv
+            - ldns
+            - openssl
 
 before_script:
-  - sh ci/install-libuv.sh
-  - sh ci/install-ldns.sh
+  - if [ "${TRAVIS_OS_NAME}" = linux ]; then sh ci/install-libuv.sh; fi
+  - if [ "${TRAVIS_OS_NAME}" = linux ]; then sh ci/install-ldns.sh; fi
 
 script:
   - mkdir build && cd build && cmake ..

--- a/ci/install-ldns.sh
+++ b/ci/install-ldns.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+VERSION=1.7.0
+ARCHIVE="https://www.nlnetlabs.nl/downloads/ldns/ldns-${VERSION}.tar.gz"
+
+set -ex
+
+cd /tmp
+wget -O "ldns-${VERSION}.tar.gz" "$ARCHIVE"
+tar -xf "ldns-${VERSION}.tar.gz"
+cd "ldns-${VERSION}"
+
+./configure --disable-dane
+make
+sudo make install
+sudo ldconfig
+sudo mkdir -p /usr/local/lib/pkgconfig
+sudo cp packaging/libldns.pc /usr/local/lib/pkgconfig/

--- a/ci/install-libuv.sh
+++ b/ci/install-libuv.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+VERSION=1.25.0
+ARCHIVE="https://github.com/libuv/libuv/archive/v${VERSION}.tar.gz"
+
+set -ex
+
+cd /tmp
+wget -O "libuv-${VERSION}.tar.gz" "$ARCHIVE"
+tar -xf "libuv-${VERSION}.tar.gz"
+cd "libuv-${VERSION}"
+
+./autogen.sh
+./configure
+make
+sudo make install
+sudo ldconfig


### PR DESCRIPTION
This change set adds configuration for Travis CI.

The build is enabled for Linux and macOS. The provided Linux build environment is relatively old so we have to build libuv and ldns from sources.