### PR TITLE
Add support for flaming over DoT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-build/
+build*/
 build_output/

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ matrix:
           packages:
             - cmake
             - libssl-dev
+            - libgnutls-dev
     - os: osx
       addons:
         homebrew:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,7 @@ find_package(PkgConfig)
 
 pkg_search_module(LIBLDNS REQUIRED libldns ldns)
 pkg_check_modules(LIBUV REQUIRED libuv)
+pkg_check_modules(LIBGNUTLS REQUIRED gnutls>=3.3)
 
 # ::-------------------------------------------------------------------------:: 
 # BUILD TARGETS
@@ -59,11 +60,14 @@ add_library(flamecore
         flame/trafgen.h
         flame/tcpsession.cpp
         flame/tcpsession.h
+        flame/tcptlssession.cpp
+        flame/tcptlssession.h
         flame/utils.cpp flame/utils.h)
 
 target_include_directories(flamecore
         PUBLIC ${LIBUV_INCLUDE_DIRS}
         PUBLIC ${LIBLDNS_INCLUDE_DIRS}
+        PRIVATE ${LIBGNUTLS_INCLUDE_DIRS}
         PUBLIC "${CMAKE_SOURCE_DIR}/3rd/TokenBucket"
         PUBLIC "${CMAKE_SOURCE_DIR}/3rd/docopt.cpp"
         PUBLIC "${CMAKE_SOURCE_DIR}/3rd/json"
@@ -74,6 +78,8 @@ target_link_libraries(flamecore
         PRIVATE ${LIBUV_LDFLAGS}
         PRIVATE ${LIBLDNS_LDFLAGS}
         PRIVATE ${LIBLDNS_LIBRARIES}
+        PRIVATE ${LIBGNUTLS_LDFLAGS}
+        PRIVATE ${LIBGNUTLS_LIBRARIES}
         )
 
 add_executable(flame

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,8 @@ add_library(flamecore
         flame/query.h
         flame/trafgen.cpp
         flame/trafgen.h
+        flame/tcpsession.cpp
+        flame/tcpsession.h
         flame/utils.cpp flame/utils.h)
 
 target_include_directories(flamecore

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Dependencies
 * Linux or OSX
 * libuv >= 1.23.0
 * libldns >= 1.7.0
+* gnutls >= 3.3
 * C++ compiler supporting C++17
 
 Build
@@ -56,6 +57,11 @@ flame localhost
 Flame target, port 5300, TCP:
 ```
 flame -p 5300 -P tcp target.test.com
+```
+
+Flame target, port 443, TCPTLS:
+```
+flame -p 443 -P tcptls target.test.com
 ```
 
 Flame target with random labels:

--- a/flame/config.h
+++ b/flame/config.h
@@ -8,9 +8,9 @@
 class Config
 {
 private:
-    long _rate_limit{0};
     std::string _output_file;
     int _verbosity{1};
+    long _rate_limit{0};
 
 public:
     Config(

--- a/flame/main.cpp
+++ b/flame/main.cpp
@@ -47,7 +47,7 @@ static const char USAGE[] =
       -f FILE          Read records from FILE, one per row, QNAME TYPE
       -p PORT          Which port to flame [default: 53]
       -F FAMILY        Internet family (inet/inet6) [default: inet]
-      -P PROTOCOL      Protocol to use (udp/tcp) [default: udp]
+      -P PROTOCOL      Protocol to use (udp/tcp/tcptls) [default: udp]
       -g GENERATOR     Generate queries with the given generator [default: static]
       -o FILE          Metrics output file, JSON format.
       -v VERBOSITY     How verbose output should be, 0 is silent [default: 1]
@@ -214,8 +214,8 @@ int main(int argc, char *argv[])
     long c_count = args["-c"].asLong();
 
     Protocol proto{Protocol::UDP};
-    if (args["-P"].asString() == "tcp") {
-        proto = Protocol::TCP;
+    if (args["-P"].asString() == "tcp" || args["-P"].asString() == "tcptls") {
+        proto = (args["-P"].asString() == "tcptls") ? Protocol::TCPTLS : Protocol::TCP;
         if (!arg_exists("-d", argc, argv))
             s_delay = 1000;
         if (!arg_exists("-q", argc, argv))
@@ -225,7 +225,7 @@ int main(int argc, char *argv[])
     } else if (args["-P"].asString() == "udp") {
         proto = Protocol::UDP;
     } else {
-        std::cerr << "protocol must be 'udp' or 'tcp'" << std::endl;
+        std::cerr << "protocol must be 'udp', 'tcp' or 'tcptls'" << std::endl;
         return 1;
     }
     auto config = std::make_shared<Config>(

--- a/flame/main.cpp
+++ b/flame/main.cpp
@@ -45,7 +45,7 @@ static const char USAGE[] =
       -r RECORD        The base record to use as the DNS query for generators [default: test.com]
       -T QTYPE         The query type to use for generators [default: A]
       -f FILE          Read records from FILE, one per row, QNAME TYPE
-      -p PORT          Which port to flame [default: 53]
+      -p PORT          Which port to flame [defaults: 53, 853 for tcptls]
       -F FAMILY        Internet family (inet/inet6) [default: inet]
       -P PROTOCOL      Protocol to use (udp/tcp/tcptls) [default: udp]
       -g GENERATOR     Generate queries with the given generator [default: static]
@@ -172,6 +172,34 @@ int main(int argc, char *argv[])
         output_file = args["-o"].asString();
     }
 
+    // these defaults change based on protocol
+    long s_delay = args["-d"].asLong();
+    long b_count = args["-q"].asLong();
+    long c_count = args["-c"].asLong();
+
+    Protocol proto{Protocol::UDP};
+    if (args["-P"].asString() == "tcp" || args["-P"].asString() == "tcptls") {
+        proto = (args["-P"].asString() == "tcptls") ? Protocol::TCPTLS : Protocol::TCP;
+        if (!arg_exists("-d", argc, argv))
+            s_delay = 1000;
+        if (!arg_exists("-q", argc, argv))
+            b_count = 100;
+        if (!arg_exists("-c", argc, argv))
+            c_count = 30;
+    } else if (args["-P"].asString() == "udp") {
+        proto = Protocol::UDP;
+    } else {
+        std::cerr << "protocol must be 'udp', 'tcp' or 'tcptls'" << std::endl;
+        return 1;
+    }
+
+    if (!args["-p"]) {
+        if (proto == Protocol::TCPTLS)
+            args["-p"] = std::string("853");
+        else
+            args["-p"] = std::string("53");
+    }
+
     auto runtime_limit = args["-l"].asLong();
 
     auto request = loop->resource<uvw::GetAddrInfoReq>();
@@ -208,26 +236,6 @@ int main(int argc, char *argv[])
         addr = uvw::details::address<uvw::IPv6>((struct sockaddr_in6 *)node->ai_addr);
     }
 
-    // these defaults change based on protocol
-    long s_delay = args["-d"].asLong();
-    long b_count = args["-q"].asLong();
-    long c_count = args["-c"].asLong();
-
-    Protocol proto{Protocol::UDP};
-    if (args["-P"].asString() == "tcp" || args["-P"].asString() == "tcptls") {
-        proto = (args["-P"].asString() == "tcptls") ? Protocol::TCPTLS : Protocol::TCP;
-        if (!arg_exists("-d", argc, argv))
-            s_delay = 1000;
-        if (!arg_exists("-q", argc, argv))
-            b_count = 100;
-        if (!arg_exists("-c", argc, argv))
-            c_count = 30;
-    } else if (args["-P"].asString() == "udp") {
-        proto = Protocol::UDP;
-    } else {
-        std::cerr << "protocol must be 'udp', 'tcp' or 'tcptls'" << std::endl;
-        return 1;
-    }
     auto config = std::make_shared<Config>(
         args["-v"].asLong(),
         output_file,

--- a/flame/main.cpp
+++ b/flame/main.cpp
@@ -101,7 +101,7 @@ void parse_flowspec(std::string spec, std::queue<std::pair<uint64_t, uint64_t>> 
 {
 
     std::vector<std::string> groups = split(spec, ';');
-    for (int i = 0; i < groups.size(); i++) {
+    for (unsigned i = 0; i < groups.size(); i++) {
         std::vector<std::string> nums = split(groups[i], ',');
         if (verbosity > 1) {
             std::cout << "adding QPS flow: " << nums[0] << "qps, " << nums[1] << "ms" << std::endl;

--- a/flame/metrics.h
+++ b/flame/metrics.h
@@ -18,8 +18,8 @@ class MetricsMgr
     std::chrono::high_resolution_clock::time_point _start_time;
     std::chrono::high_resolution_clock::time_point _stop_time;
 
-    std::shared_ptr<Config> _config;
     std::shared_ptr<uvw::Loop> _loop;
+    std::shared_ptr<Config> _config;
 
     // aggregation and output
     std::shared_ptr<uvw::TimerHandle> _metric_period_timer;

--- a/flame/query.cpp
+++ b/flame/query.cpp
@@ -144,7 +144,7 @@ QueryGenerator::QueryTpt QueryGenerator::next_tcp(const std::vector<uint16_t> &i
     // get total len
     size_t total_len{0};
     auto r = _reqs;
-    for (auto id : id_list) {
+    for ([[maybe_unused]] auto id : id_list) {
         // include 2 byte size required in tcp dns
         total_len += 2 + _wire_buffers[r++ % _wire_buffers.size()].second;
     }

--- a/flame/query.h
+++ b/flame/query.h
@@ -33,7 +33,7 @@ public:
     using WireTpt = std::pair<uint8_t *, size_t>;
 
 protected:
-    long _loops{0};
+    unsigned long _loops{0};
     std::string _qclass;
     std::string _qname;
     std::string _qtype;
@@ -71,7 +71,7 @@ public:
 
     void set_args(const std::vector<std::string> &args);
 
-    void set_loops(long l)
+    void set_loops(unsigned long l)
     {
         _loops = l;
     }
@@ -96,7 +96,7 @@ public:
         _dnssec = d;
     }
 
-    long loops() const
+    unsigned long loops() const
     {
         return _loops;
     }

--- a/flame/tcpsession.cpp
+++ b/flame/tcpsession.cpp
@@ -30,16 +30,23 @@ void TCPSession::on_connect_event()
     _connection_ready();
 }
 
-// remote peer closed connection, sent EOF
+// remote peer closed connection
 void TCPSession::on_end_event()
 {
-    _handle->shutdown();
+    _handle->close();
 }
 
-// we've closed, send EOF
+// all local writes now finished
 void TCPSession::on_shutdown_event()
 {
     _handle->close();
+}
+
+// gracefully terminate the session
+void TCPSession::close()
+{
+    _handle->stop();
+    _handle->shutdown();
 }
 
 // accumulate data and try to extract DNS messages

--- a/flame/tcpsession.cpp
+++ b/flame/tcpsession.cpp
@@ -77,6 +77,9 @@ void TCPSession::receive_data(const char data[], size_t len)
             std::memcpy(data.get(), _buffer.data() + sizeof(size), size);
             _buffer.erase(0, sizeof(size) + size);
             _got_dns_msg(std::move(data), size);
+        } else {
+            // Nope, we need more data.
+            break;
         }
     }
 }

--- a/flame/tcpsession.cpp
+++ b/flame/tcpsession.cpp
@@ -1,0 +1,78 @@
+#include <cstdint>
+#include <cstring>
+#include <utility>
+
+#include "tcpsession.h"
+
+TCPSession::TCPSession(std::shared_ptr<uvw::TcpHandle> handle,
+                       malformed_data_cb malformed_data_handler,
+                       got_dns_msg_cb got_dns_msg_handler)
+    : _handle{handle},
+      _malformed_data{std::move(malformed_data_handler)},
+      _got_dns_msg{std::move(got_dns_msg_handler)}
+{
+}
+
+TCPSession::~TCPSession()
+{
+}
+
+void TCPSession::on_data_event(const char data[], size_t len)
+{
+    receive_data(data, len);
+}
+
+// remote peer closed connection, sent EOF
+void TCPSession::on_end_event()
+{
+    _handle->shutdown();
+}
+
+// we've closed, send EOF
+void TCPSession::on_shutdown_event()
+{
+    _handle->close();
+}
+
+void TCPSession::write(std::unique_ptr<char[]> data, size_t len)
+{
+    send_data(std::move(data), len);
+}
+
+// accumulate data and try to extract DNS messages
+void TCPSession::receive_data(const char data[], size_t len)
+{
+    const size_t MIN_DNS_QUERY_SIZE = 17;
+    const size_t MAX_DNS_QUERY_SIZE = 512;
+
+    _buffer.append(data, len);
+
+    for(;;) {
+        std::uint16_t size;
+
+        if (_buffer.size() < sizeof(size))
+            break;
+
+        // size is in network byte order.
+        size = static_cast<unsigned char>(_buffer[1]) |
+               static_cast<unsigned char>(_buffer[0]) << 8;
+
+        if (size < MIN_DNS_QUERY_SIZE || size > MAX_DNS_QUERY_SIZE) {
+            _malformed_data();
+            break;
+        }
+
+        if (_buffer.size() >= sizeof(size) + size) {
+            auto data = std::make_unique<char[]>(size);
+            std::memcpy(data.get(), _buffer.data() + sizeof(size), size);
+            _buffer.erase(0, sizeof(size) + size);
+            _got_dns_msg(std::move(data), size);
+        }
+    }
+}
+
+// send data, giving data ownership to async library
+void TCPSession::send_data(std::unique_ptr<char[]> data, size_t len)
+{
+    _handle->write(std::move(data), len);
+}

--- a/flame/tcpsession.cpp
+++ b/flame/tcpsession.cpp
@@ -30,11 +30,6 @@ void TCPSession::on_connect_event()
     _connection_ready();
 }
 
-void TCPSession::on_data_event(const char data[], size_t len)
-{
-    receive_data(data, len);
-}
-
 // remote peer closed connection, sent EOF
 void TCPSession::on_end_event()
 {
@@ -45,11 +40,6 @@ void TCPSession::on_end_event()
 void TCPSession::on_shutdown_event()
 {
     _handle->close();
-}
-
-void TCPSession::write(std::unique_ptr<char[]> data, size_t len)
-{
-    send_data(std::move(data), len);
 }
 
 // accumulate data and try to extract DNS messages
@@ -85,7 +75,7 @@ void TCPSession::receive_data(const char data[], size_t len)
 }
 
 // send data, giving data ownership to async library
-void TCPSession::send_data(std::unique_ptr<char[]> data, size_t len)
+void TCPSession::write(std::unique_ptr<char[]> data, size_t len)
 {
     _handle->write(std::move(data), len);
 }

--- a/flame/tcpsession.cpp
+++ b/flame/tcpsession.cpp
@@ -6,15 +6,28 @@
 
 TCPSession::TCPSession(std::shared_ptr<uvw::TcpHandle> handle,
                        malformed_data_cb malformed_data_handler,
-                       got_dns_msg_cb got_dns_msg_handler)
+                       got_dns_msg_cb got_dns_msg_handler,
+                       connection_ready_cb connection_ready_handler)
     : _handle{handle},
       _malformed_data{std::move(malformed_data_handler)},
-      _got_dns_msg{std::move(got_dns_msg_handler)}
+      _got_dns_msg{std::move(got_dns_msg_handler)},
+      _connection_ready{std::move(connection_ready_handler)}
 {
 }
 
 TCPSession::~TCPSession()
 {
+}
+
+// do any pre-connection setup, return true if all OK.
+bool TCPSession::setup()
+{
+    return true;
+}
+
+void TCPSession::on_connect_event()
+{
+    _connection_ready();
 }
 
 void TCPSession::on_data_event(const char data[], size_t len)

--- a/flame/tcpsession.h
+++ b/flame/tcpsession.h
@@ -1,0 +1,69 @@
+#pragma once
+
+#include <cstdint>
+#include <cstring>
+#include <functional>
+#include <memory>
+#include <utility>
+
+class TCPSession
+{
+public:
+    using error_cb = std::function<void()>;
+    using query_cb = std::function<void(std::unique_ptr<char[]> data, size_t size)>;
+
+    void received(const char data[], size_t len)
+    {
+        buffer.append(data, len);
+
+        while (try_yield_message()) {
+        }
+    }
+
+    void on_error(error_cb handler)
+    {
+        error = std::move(handler);
+    }
+
+    void on_query(query_cb handler)
+    {
+        query = std::move(handler);
+    }
+
+private:
+    bool try_yield_message()
+    {
+        const size_t MIN_DNS_QUERY_SIZE = 17;
+        const size_t MAX_DNS_QUERY_SIZE = 512;
+
+        std::uint16_t size = 0;
+
+        if (buffer.size() < sizeof(size)) {
+            return false;
+        }
+
+        // size is in network byte order.
+        size = static_cast<unsigned char>(buffer[1]) |
+               static_cast<unsigned char>(buffer[0]) << 8;
+
+        if (size < MIN_DNS_QUERY_SIZE || size > MAX_DNS_QUERY_SIZE) {
+            error();
+            return false;
+        }
+
+        if (buffer.size() >= sizeof(size) + size) {
+            auto data = std::make_unique<char[]>(size);
+            memcpy(data.get(), buffer.data() + sizeof(size), size);
+            buffer.erase(0, sizeof(size) + size);
+
+            query(std::move(data), size);
+            return true;
+        }
+
+        return false;
+    }
+
+    std::string buffer;
+    error_cb error;
+    query_cb query;
+};

--- a/flame/tcpsession.h
+++ b/flame/tcpsession.h
@@ -14,7 +14,7 @@ public:
     TCPSession(std::shared_ptr<uvw::TcpHandle> handle,
                malformed_data_cb malformed_data_handler,
                got_dns_msg_cb got_dns_msg_handler,
-               connection_ready_cb connection_ready_hander);
+               connection_ready_cb connection_ready_handler);
     virtual ~TCPSession();
 
     virtual bool setup();

--- a/flame/tcpsession.h
+++ b/flame/tcpsession.h
@@ -20,15 +20,11 @@ public:
     virtual bool setup();
 
     virtual void on_connect_event();
-    virtual void on_data_event(const char data[], size_t len);
     virtual void on_end_event();
     virtual void on_shutdown_event();
 
-    virtual void write(std::unique_ptr<char[]> data, size_t len);
-
-protected:
     virtual void receive_data(const char data[], size_t len);
-    virtual void send_data(std::unique_ptr<char[]> data, size_t len);
+    virtual void write(std::unique_ptr<char[]> data, size_t len);
 
 private:
     std::string _buffer;

--- a/flame/tcpsession.h
+++ b/flame/tcpsession.h
@@ -9,12 +9,17 @@ class TCPSession {
 public:
     using malformed_data_cb = std::function<void()>;
     using got_dns_msg_cb = std::function<void(std::unique_ptr<char[]> data, size_t size)>;
+    using connection_ready_cb = std::function<void()>;
 
     TCPSession(std::shared_ptr<uvw::TcpHandle> handle,
                malformed_data_cb malformed_data_handler,
-               got_dns_msg_cb got_dns_msg_handler);
+               got_dns_msg_cb got_dns_msg_handler,
+               connection_ready_cb connection_ready_hander);
     virtual ~TCPSession();
 
+    virtual bool setup();
+
+    virtual void on_connect_event();
     virtual void on_data_event(const char data[], size_t len);
     virtual void on_end_event();
     virtual void on_shutdown_event();
@@ -30,4 +35,5 @@ private:
     std::shared_ptr<uvw::TcpHandle> _handle;
     malformed_data_cb _malformed_data;
     got_dns_msg_cb _got_dns_msg;
+    connection_ready_cb _connection_ready;
 };

--- a/flame/tcpsession.h
+++ b/flame/tcpsession.h
@@ -23,6 +23,7 @@ public:
     virtual void on_end_event();
     virtual void on_shutdown_event();
 
+    virtual void close();
     virtual void receive_data(const char data[], size_t len);
     virtual void write(std::unique_ptr<char[]> data, size_t len);
 

--- a/flame/tcptlssession.cpp
+++ b/flame/tcptlssession.cpp
@@ -79,7 +79,7 @@ void TCPTLSSession::on_connect_event()
     do_handshake();
 }
 
-void TCPTLSSession::on_data_event(const char data[], size_t len)
+void TCPTLSSession::receive_data(const char data[], size_t len)
 {
     _pull_buffer.append(data, len);
     if (!_handshake_done) {
@@ -136,6 +136,6 @@ int TCPTLSSession::gnutls_push(const void *buf, size_t len)
 {
     auto data = std::make_unique<char[]>(len);
     memcpy(data.get(), const_cast<char *>(reinterpret_cast<const char *>(buf)), len);
-    TCPSession::send_data(std::move(data), len);
+    TCPSession::write(std::move(data), len);
     return len;
 }

--- a/flame/tcptlssession.cpp
+++ b/flame/tcptlssession.cpp
@@ -1,0 +1,141 @@
+#include <algorithm>
+#include <cstring>
+#include <iostream>
+
+#include "tcptlssession.h"
+
+static ssize_t gnutls_pull_trampoline(gnutls_transport_ptr_t h, void *buf, size_t len)
+{
+    auto session = static_cast<TCPTLSSession*>(h);
+    return session->gnutls_pull(buf, len);
+}
+
+static ssize_t gnutls_push_trampoline(gnutls_transport_ptr_t h, const void *buf, size_t len)
+{
+    auto session = static_cast<TCPTLSSession*>(h);
+    return session->gnutls_push(buf, len);
+}
+
+TCPTLSSession::TCPTLSSession(std::shared_ptr<uvw::TcpHandle> handle,
+                             TCPSession::malformed_data_cb malformed_data_handler,
+                             TCPSession::got_dns_msg_cb got_dns_msg_handler,
+                             TCPSession::connection_ready_cb connection_ready_handler,
+                             handshake_error_cb handshake_error_handler)
+    : TCPSession(handle, malformed_data_handler, got_dns_msg_handler, connection_ready_handler),
+      _handshake_done{false}, _handshake_error{handshake_error_handler}
+{
+}
+
+TCPTLSSession::~TCPTLSSession()
+{
+    gnutls_certificate_free_credentials(_gnutls_cert_credentials);
+    gnutls_deinit(_gnutls_session);
+}
+
+bool TCPTLSSession::setup()
+{
+    int ret;
+
+    ret = gnutls_init(&_gnutls_session, GNUTLS_CLIENT | GNUTLS_NONBLOCK);
+    if (ret != GNUTLS_E_SUCCESS) {
+        std::cerr << "GNUTLS init failed: " << gnutls_strerror(ret) << std::endl;
+        return false;
+    }
+
+    ret = gnutls_set_default_priority(_gnutls_session);
+    if (ret != GNUTLS_E_SUCCESS) {
+        std::cerr << "GNUTLS failed to set default priority: " << gnutls_strerror(ret) << std::endl;
+        return false;
+    }
+
+    ret = gnutls_certificate_allocate_credentials(&_gnutls_cert_credentials);
+    if (ret < 0) {
+        std::cerr << "GNUTLS failed to allocate credentials: " << gnutls_strerror(ret) << std::endl;
+        return false;
+    }
+
+    ret = gnutls_certificate_set_x509_system_trust(_gnutls_cert_credentials);
+    if (ret < 0) {
+        std::cerr << "GNUTLS failed to set system trust: " << gnutls_strerror(ret) << std::endl;
+        return false;
+    }
+
+    ret = gnutls_credentials_set(_gnutls_session, GNUTLS_CRD_CERTIFICATE,
+                                 _gnutls_cert_credentials);
+    if (ret < 0) {
+        std::cerr << "GNUTLS failed to set system credentials" << gnutls_strerror(ret) << std::endl;
+        return false;
+    }
+
+    gnutls_transport_set_ptr(_gnutls_session, this);
+    gnutls_transport_set_pull_function(_gnutls_session, gnutls_pull_trampoline);
+    gnutls_transport_set_push_function(_gnutls_session, gnutls_push_trampoline);
+    gnutls_handshake_set_timeout(_gnutls_session, GNUTLS_DEFAULT_HANDSHAKE_TIMEOUT);
+    return true;
+}
+
+void TCPTLSSession::on_connect_event()
+{
+    do_handshake();
+}
+
+void TCPTLSSession::on_data_event(const char data[], size_t len)
+{
+    _pull_buffer.append(data, len);
+    if (!_handshake_done) {
+        do_handshake();
+    } else {
+        for (;;) {
+            char buf[2048];
+            ssize_t len = gnutls_record_recv(_gnutls_session, buf, sizeof(buf));
+            if (len > 0) {
+                TCPSession::receive_data(buf, len);
+            } else {
+                break;
+            }
+        }
+    }
+}
+
+void TCPTLSSession::write(std::unique_ptr<char[]> data, size_t len)
+{
+    ssize_t sent = gnutls_record_send(_gnutls_session, data.get(), len);
+    if (sent < 0) {
+        std::cerr << "Error in sending data: " << gnutls_strerror(sent) << std::endl;
+    }
+}
+
+void TCPTLSSession::do_handshake()
+{
+    int err = gnutls_handshake(_gnutls_session);
+    if (err == GNUTLS_E_SUCCESS) {
+        _handshake_done = true;
+        TCPSession::on_connect_event();
+    } else if (err < 0 && gnutls_error_is_fatal(err)) {
+        std::cerr << "Handshake failed: " << gnutls_strerror(err) << std::endl;
+        _handshake_error();
+    } else if (err != GNUTLS_E_AGAIN && err != GNUTLS_E_INTERRUPTED) {
+        std::cout << "Handshake " << gnutls_strerror(err) << std::endl;
+    }
+}
+
+int TCPTLSSession::gnutls_pull(void *buf, size_t len)
+{
+    if (!_pull_buffer.empty()) {
+        len = std::min(len, _pull_buffer.size());
+        std::memcpy(buf, _pull_buffer.data(), len);
+        _pull_buffer.erase(0, len);
+        return len;
+    }
+
+    errno = EAGAIN;
+    return -1;
+}
+
+int TCPTLSSession::gnutls_push(const void *buf, size_t len)
+{
+    auto data = std::make_unique<char[]>(len);
+    memcpy(data.get(), const_cast<char *>(reinterpret_cast<const char *>(buf)), len);
+    TCPSession::send_data(std::move(data), len);
+    return len;
+}

--- a/flame/tcptlssession.h
+++ b/flame/tcptlssession.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <gnutls/gnutls.h>
+
+#include "tcpsession.h"
+
+class TCPTLSSession : public TCPSession
+{
+public:
+    using handshake_error_cb =  std::function<void()>;
+
+    TCPTLSSession(std::shared_ptr<uvw::TcpHandle> handle,
+                  TCPSession::malformed_data_cb malformed_data_handler,
+                  TCPSession::got_dns_msg_cb got_dns_msg_handler,
+                  TCPSession::connection_ready_cb connection_ready_handler,
+                  handshake_error_cb handshake_error_handler);
+    virtual ~TCPTLSSession();
+
+    virtual bool setup();
+
+    virtual void on_connect_event();
+    virtual void on_data_event(const char data[], size_t len);
+
+    virtual void write(std::unique_ptr<char[]> data, size_t len);
+
+    int gnutls_pull(void *buf, size_t len);
+    int gnutls_push(const void *buf, size_t len);
+
+protected:
+    void do_handshake();
+
+private:
+    bool _handshake_done;
+    handshake_error_cb _handshake_error;
+    std::string _pull_buffer;
+
+    gnutls_session_t _gnutls_session;
+    gnutls_certificate_credentials_t _gnutls_cert_credentials;
+};

--- a/flame/tcptlssession.h
+++ b/flame/tcptlssession.h
@@ -19,8 +19,8 @@ public:
     virtual bool setup();
 
     virtual void on_connect_event();
-    virtual void on_data_event(const char data[], size_t len);
 
+    virtual void receive_data(const char data[], size_t len);
     virtual void write(std::unique_ptr<char[]> data, size_t len);
 
     int gnutls_pull(void *buf, size_t len);

--- a/flame/tcptlssession.h
+++ b/flame/tcptlssession.h
@@ -20,6 +20,7 @@ public:
 
     virtual void on_connect_event();
 
+    virtual void close();
     virtual void receive_data(const char data[], size_t len);
     virtual void write(std::unique_ptr<char[]> data, size_t len);
 
@@ -30,7 +31,7 @@ protected:
     void do_handshake();
 
 private:
-    bool _handshake_done;
+    enum class LinkState { HANDSHAKE, DATA, CLOSE } _tls_state;
     handshake_error_cb _handshake_error;
     std::string _pull_buffer;
 

--- a/flame/trafgen.cpp
+++ b/flame/trafgen.cpp
@@ -7,72 +7,12 @@
 #include <string>
 
 #include "trafgen.h"
+#include "tcpsession.h"
 
 #include <ldns/rbtree.h>
 
 #include <ldns/host2wire.h>
 #include <ldns/wire2host.h>
-
-static const size_t MIN_DNS_QUERY_SIZE = 17;
-static const size_t MAX_DNS_QUERY_SIZE = 512;
-
-class TCPSession
-{
-public:
-    using error_cb = std::function<void()>;
-    using query_cb = std::function<void(std::unique_ptr<char[]> data, size_t size)>;
-
-    bool try_yield_message()
-    {
-        uint16_t size = 0;
-
-        if (buffer.size() < sizeof(size)) {
-            return false;
-        }
-
-        memcpy(&size, buffer.data(), sizeof(size));
-        size = ntohs(size);
-
-        if (size < MIN_DNS_QUERY_SIZE || size > MAX_DNS_QUERY_SIZE) {
-            error();
-            return false;
-        }
-
-        if (buffer.size() >= sizeof(size) + size) {
-            auto data = std::make_unique<char[]>(size);
-            memcpy(data.get(), buffer.data() + sizeof(size), size);
-            buffer.erase(0, sizeof(size) + size);
-
-            query(std::move(data), size);
-            return true;
-        }
-
-        return false;
-    }
-
-    void received(const char data[], size_t len)
-    {
-        buffer.append(data, len);
-
-        while (try_yield_message()) {
-        }
-    }
-
-    void on_error(error_cb handler)
-    {
-        error = std::move(handler);
-    }
-
-    void on_query(query_cb handler)
-    {
-        query = std::move(handler);
-    }
-
-private:
-    std::string buffer;
-    error_cb error;
-    query_cb query;
-};
 
 TrafGen::TrafGen(std::shared_ptr<uvw::Loop> l,
     std::shared_ptr<Metrics> s,

--- a/flame/trafgen.cpp
+++ b/flame/trafgen.cpp
@@ -353,7 +353,7 @@ void TrafGen::start()
         _sender_timer->on<uvw::TimerEvent>([this](const uvw::TimerEvent &event, uvw::TimerHandle &h) {
             if (_traf_config->protocol == Protocol::UDP) {
                 udp_send();
-            } else if (_traf_config->protocol == Protocol::TCP) {
+            } else if (_traf_config->protocol == Protocol::TCP || _traf_config->protocol == Protocol::TCPTLS) {
                 start_tcp_session();
             }
         });

--- a/flame/trafgen.cpp
+++ b/flame/trafgen.cpp
@@ -196,7 +196,7 @@ void TrafGen::start_tcp_session()
 
     // INCOMING: remote peer sends data, pass to session
     _tcp_handle->on<uvw::DataEvent>([this](uvw::DataEvent &event, uvw::TcpHandle &h) {
-        _tcp_session->on_data_event(event.data.get(), event.length);
+        _tcp_session->receive_data(event.data.get(), event.length);
     });
 
     // OUTGOING: write operation has finished

--- a/flame/trafgen.cpp
+++ b/flame/trafgen.cpp
@@ -247,8 +247,7 @@ void TrafGen::start_wait_timer_for_tcp_finish()
         // shut down timer and connection. TCP CloseEvent will handle restarting sends.
         _finish_session_timer->stop();
         _finish_session_timer->close();
-        _tcp_handle->stop();
-        _tcp_handle->shutdown();
+        _tcp_handle->close();
     });
     _finish_session_timer->start(uvw::TimerHandle::Time{1}, uvw::TimerHandle::Time{50});
 }

--- a/flame/trafgen.h
+++ b/flame/trafgen.h
@@ -16,6 +16,7 @@
 enum class Protocol {
     UDP,
     TCP,
+    TCPTLS,
 };
 
 struct TrafGenConfig {

--- a/flame/trafgen.h
+++ b/flame/trafgen.h
@@ -9,6 +9,7 @@
 #include "config.h"
 #include "metrics.h"
 #include "query.h"
+#include "tcpsession.h"
 
 #include <TokenBucket.h>
 #include <uvw.hpp>
@@ -41,6 +42,7 @@ class TrafGen
 
     std::shared_ptr<uvw::UDPHandle> _udp_handle;
     std::shared_ptr<uvw::TcpHandle> _tcp_handle;
+    std::shared_ptr<TCPSession> _tcp_session;
 
     std::shared_ptr<uvw::TimerHandle> _sender_timer;
     std::shared_ptr<uvw::TimerHandle> _timeout_timer;


### PR DESCRIPTION
I've dug out some patches we did a while back to add TCP/TLS support (i.e. DoT) to Flamethrower, and updated them to the current tree.

I also added some fixes for warnings when building using Debian Unstable's GCC 8.2.0.