### PR TITLE
DNS over QUIC support (old reference)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,8 @@ script:
   - make all tests
   - ./tests
   - cd ..
-  - mkdir quic-build && cd quic-build && cmake -DQUIC_ENABLE=ON ..
+  - mkdir quic-build && cd quic-build
+  - if [ "${TRAVIS_OS_NAME}" = linux ]; then sh cmake -DQUIC_ENABLE=ON ..; fi
+  - if [ "${TRAVIS_OS_NAME}" = osx ]; then sh PKG_CONFIG_PATH=/usr/local/opt/openssl@1.1/lib/pkgconfig cmake -DQUIC_ENABLE=ON ..; fi
   - make all tests
   - ./tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ script:
   - mkdir build && cd build && cmake ..
   - make all tests
   - ./tests
+  - cd ..
   - mkdir quic-build && cd quic-build && cmake -DQUIC_ENABLE=ON ..
   - make all tests
   - ./tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ matrix:
             - cmake
             - libssl-dev
             - libgnutls-dev
+            - openssl
     - os: osx
       addons:
         homebrew:
@@ -24,8 +25,14 @@ matrix:
 before_script:
   - if [ "${TRAVIS_OS_NAME}" = linux ]; then sh ci/install-libuv.sh; fi
   - if [ "${TRAVIS_OS_NAME}" = linux ]; then sh ci/install-ldns.sh; fi
+  - sh ci/install-quicly.sh
 
 script:
+  - ln -s /tmp/quicly 3rd/
   - mkdir build && cd build && cmake ..
+  - make all tests
+  - ./tests
+  - mkdir quic-build && cd quic-build
+  - cmake -DQUIC_ENABLE=ON ..
   - make all tests
   - ./tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,6 @@ script:
   - mkdir build && cd build && cmake ..
   - make all tests
   - ./tests
-  - mkdir quic-build && cd quic-build
-  - cmake -DQUIC_ENABLE=ON ..
+  - mkdir quic-build && cd quic-build && cmake -DQUIC_ENABLE=ON ..
   - make all tests
   - ./tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ script:
   - ./tests
   - cd ..
   - mkdir quic-build && cd quic-build
-  - if [ "${TRAVIS_OS_NAME}" = linux ]; then sh cmake -DQUIC_ENABLE=ON ..; fi
-  - if [ "${TRAVIS_OS_NAME}" = osx ]; then sh PKG_CONFIG_PATH=/usr/local/opt/openssl@1.1/lib/pkgconfig cmake -DQUIC_ENABLE=ON ..; fi
+  - if [ "${TRAVIS_OS_NAME}" = linux ]; then cmake -DQUIC_ENABLE=ON ..; fi
+  - if [ "${TRAVIS_OS_NAME}" = osx ]; then PKG_CONFIG_PATH=/usr/local/opt/openssl@1.1/lib/pkgconfig cmake -DQUIC_ENABLE=ON ..; fi
   - make all tests
   - ./tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,7 @@ add_library(flamecore
 target_include_directories(flamecore
         PUBLIC ${LIBUV_INCLUDE_DIRS}
         PUBLIC ${LIBLDNS_INCLUDE_DIRS}
-        PUBLIC ${OPENSSL_INCLUDE_DIR}
+        PUBLIC ${OPENSSL_INCLUDE_DIRS}
         PRIVATE ${LIBGNUTLS_INCLUDE_DIRS}
         )
 
@@ -88,7 +88,7 @@ target_link_libraries(flamecore
         PRIVATE ${LIBLDNS_LIBRARIES}
         PRIVATE ${LIBGNUTLS_LDFLAGS}
         PRIVATE ${LIBGNUTLS_LIBRARIES}
-        PRIVATE ${OPENSSL_LDFLAGS}
+        PRIVATE ${OPENSSL_LIBRARIES}
         PRIVATE "-L ${CMAKE_SOURCE_DIR}/3rd/quicly/build/ -lquicly"
         picotls
         )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,8 @@ target_include_directories(flamecore
         PUBLIC "${CMAKE_SOURCE_DIR}/3rd/docopt.cpp"
         PUBLIC "${CMAKE_SOURCE_DIR}/3rd/json"
         PUBLIC "${CMAKE_SOURCE_DIR}/3rd/uvw"
+        PUBLIC "${CMAKE_SOURCE_DIR}/3rd/quicly/include"
+        PUBLIC "${CMAKE_SOURCE_DIR}/3rd/quicly/deps/picotls/include"
         )
 
 target_link_libraries(flamecore

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,9 +53,6 @@ pkg_check_modules(OPENSSL REQUIRED libcrypto>=1.1)
 # ::-------------------------------------------------------------------------:: 
 
 add_library(flamecore
-        3rd/quicly/deps/picotls/lib/openssl.c
-        3rd/quicly/deps/picotls/lib/pembase64.c
-        3rd/quicly/deps/picotls/lib/picotls.c
         flame/metrics.cpp
         flame/metrics.h
         flame/query.cpp
@@ -93,7 +90,23 @@ target_link_libraries(flamecore
         PRIVATE ${LIBGNUTLS_LIBRARIES}
         PRIVATE ${OPENSSL_LDFLAGS}
         PRIVATE "-L ${CMAKE_SOURCE_DIR}/3rd/quicly/build/ -lquicly"
+        picotls
         )
+
+add_library(picotls STATIC
+        3rd/quicly/deps/picotls/lib/openssl.c
+        3rd/quicly/deps/picotls/lib/pembase64.c
+        3rd/quicly/deps/picotls/lib/picotls.c
+)
+
+target_include_directories(picotls
+        PUBLIC "${CMAKE_SOURCE_DIR}/3rd/quicly/deps/picotls/include"
+        PUBLIC ${OPENSSL_INCLUDE_DIRS}
+)
+
+target_link_libraries(picotls
+        PUBLIC ${OPENSSL_LDFLAGS}
+)
 
 add_executable(flame
         3rd/docopt.cpp/docopt.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,8 @@ add_compile_options(-Wall)
 # Find and setup all dependencies BEFORE declaring targets.
 # ::-------------------------------------------------------------------------:: 
 
-find_package(PkgConfig)
+find_package(PkgConfig REQUIRED)
+find_package(OpenSSL REQUIRED)
 
 pkg_search_module(LIBLDNS REQUIRED libldns ldns)
 pkg_check_modules(LIBUV REQUIRED libuv)
@@ -52,6 +53,9 @@ pkg_check_modules(LIBGNUTLS REQUIRED gnutls>=3.3)
 # ::-------------------------------------------------------------------------:: 
 
 add_library(flamecore
+        3rd/quicly/deps/picotls/lib/openssl.c
+        3rd/quicly/deps/picotls/lib/pembase64.c
+        3rd/quicly/deps/picotls/lib/picotls.c
         flame/metrics.cpp
         flame/metrics.h
         flame/query.cpp
@@ -62,11 +66,13 @@ add_library(flamecore
         flame/tcpsession.h
         flame/tcptlssession.cpp
         flame/tcptlssession.h
-        flame/utils.cpp flame/utils.h)
+        flame/utils.cpp
+        flame/utils.h)
 
 target_include_directories(flamecore
         PUBLIC ${LIBUV_INCLUDE_DIRS}
         PUBLIC ${LIBLDNS_INCLUDE_DIRS}
+        PUBLIC ${OPENSSL_INCLUDE_DIR}
         PRIVATE ${LIBGNUTLS_INCLUDE_DIRS}
         PUBLIC "${CMAKE_SOURCE_DIR}/3rd/TokenBucket"
         PUBLIC "${CMAKE_SOURCE_DIR}/3rd/docopt.cpp"
@@ -82,6 +88,7 @@ target_link_libraries(flamecore
         PRIVATE ${LIBLDNS_LIBRARIES}
         PRIVATE ${LIBGNUTLS_LDFLAGS}
         PRIVATE ${LIBGNUTLS_LIBRARIES}
+        PRIVATE "-L ${CMAKE_SOURCE_DIR}/3rd/quicly/build/ -lquicly"
         )
 
 add_executable(flame

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,9 @@ target_include_directories(flamecore
         PUBLIC ${LIBLDNS_INCLUDE_DIRS}
         PUBLIC ${OPENSSL_INCLUDE_DIR}
         PRIVATE ${LIBGNUTLS_INCLUDE_DIRS}
+        )
+
+target_include_directories(flamecore SYSTEM
         PUBLIC "${CMAKE_SOURCE_DIR}/3rd/TokenBucket"
         PUBLIC "${CMAKE_SOURCE_DIR}/3rd/docopt.cpp"
         PUBLIC "${CMAKE_SOURCE_DIR}/3rd/json"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,7 @@ pkg_check_modules(LIBGNUTLS REQUIRED gnutls>=3.3)
 
 option(QUIC_ENABLE "Enable QUIC support" OFF)
 if (QUIC_ENABLE)
-    pkg_check_modules(OPENSSL REQUIRED libcrypto>=1.1)
+    pkg_check_modules(OPENSSL REQUIRED libcrypto>=1.0.2)
     message(STATUS "QUIC support is enabled")
 else()
     message(STATUS "QUIC support is disabled")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,11 +42,11 @@ add_compile_options(-Wall)
 # ::-------------------------------------------------------------------------:: 
 
 find_package(PkgConfig REQUIRED)
-find_package(OpenSSL REQUIRED)
 
 pkg_search_module(LIBLDNS REQUIRED libldns ldns)
 pkg_check_modules(LIBUV REQUIRED libuv)
 pkg_check_modules(LIBGNUTLS REQUIRED gnutls>=3.3)
+pkg_check_modules(OPENSSL REQUIRED libcrypto>=1.1)
 
 # ::-------------------------------------------------------------------------:: 
 # BUILD TARGETS
@@ -88,6 +88,7 @@ target_link_libraries(flamecore
         PRIVATE ${LIBLDNS_LIBRARIES}
         PRIVATE ${LIBGNUTLS_LDFLAGS}
         PRIVATE ${LIBGNUTLS_LIBRARIES}
+        PRIVATE ${OPENSSL_LDFLAGS}
         PRIVATE "-L ${CMAKE_SOURCE_DIR}/3rd/quicly/build/ -lquicly"
         )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,10 @@ if (NOT CMAKE_BUILD_TYPE)
 endif()
 # ::-------------------------------------------------------------------------::
 
+# this is the source of truth for flamethrower version, which will be written to flame.h include file.
 project(flamethrower VERSION 0.10.0)
+set(FLAME_VERSION_NUM ${PROJECT_VERSION})
+set(FLAME_VERSION "Flamethrower ${PROJECT_VERSION}")
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 
@@ -46,7 +49,14 @@ find_package(PkgConfig REQUIRED)
 pkg_search_module(LIBLDNS REQUIRED libldns ldns)
 pkg_check_modules(LIBUV REQUIRED libuv)
 pkg_check_modules(LIBGNUTLS REQUIRED gnutls>=3.3)
-pkg_check_modules(OPENSSL REQUIRED libcrypto>=1.1)
+
+option(QUIC_ENABLE "Enable QUIC support" OFF)
+if (QUIC_ENABLE)
+    pkg_check_modules(OPENSSL REQUIRED libcrypto>=1.1)
+    message(STATUS "QUIC support is enabled")
+else()
+    message(STATUS "QUIC support is disabled")
+endif()
 
 # ::-------------------------------------------------------------------------:: 
 # BUILD TARGETS
@@ -69,7 +79,6 @@ add_library(flamecore
 target_include_directories(flamecore
         PUBLIC ${LIBUV_INCLUDE_DIRS}
         PUBLIC ${LIBLDNS_INCLUDE_DIRS}
-        PUBLIC ${OPENSSL_INCLUDE_DIRS}
         PRIVATE ${LIBGNUTLS_INCLUDE_DIRS}
         )
 
@@ -78,8 +87,6 @@ target_include_directories(flamecore SYSTEM
         PUBLIC "${CMAKE_SOURCE_DIR}/3rd/docopt.cpp"
         PUBLIC "${CMAKE_SOURCE_DIR}/3rd/json"
         PUBLIC "${CMAKE_SOURCE_DIR}/3rd/uvw"
-        PUBLIC "${CMAKE_SOURCE_DIR}/3rd/quicly/include"
-        PUBLIC "${CMAKE_SOURCE_DIR}/3rd/quicly/deps/picotls/include"
         )
 
 target_link_libraries(flamecore
@@ -88,11 +95,21 @@ target_link_libraries(flamecore
         PRIVATE ${LIBLDNS_LIBRARIES}
         PRIVATE ${LIBGNUTLS_LDFLAGS}
         PRIVATE ${LIBGNUTLS_LIBRARIES}
+        )
+
+if (QUIC_ENABLE)
+target_include_directories(flamecore
+        PUBLIC ${OPENSSL_INCLUDE_DIRS}
+        )
+target_include_directories(flamecore SYSTEM
+        PUBLIC "${CMAKE_SOURCE_DIR}/3rd/quicly/include"
+        PUBLIC "${CMAKE_SOURCE_DIR}/3rd/quicly/deps/picotls/include"
+        )
+target_link_libraries(flamecore
         PRIVATE ${OPENSSL_LIBRARIES}
         PRIVATE "-L ${CMAKE_SOURCE_DIR}/3rd/quicly/build/ -lquicly"
         picotls
         )
-
 add_library(picotls STATIC
         3rd/quicly/deps/picotls/lib/openssl.c
         3rd/quicly/deps/picotls/lib/pembase64.c
@@ -107,6 +124,7 @@ target_include_directories(picotls
 target_link_libraries(picotls
         PUBLIC ${OPENSSL_LDFLAGS}
 )
+endif()
 
 add_executable(flame
         3rd/docopt.cpp/docopt.cpp
@@ -133,3 +151,7 @@ target_include_directories(tests
 target_link_libraries(tests
         PRIVATE flamecore
         )
+
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
+configure_file(flame/flame.h.in flame.h @ONLY)
+

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This code is released under Apache License 2.0. You can find terms and condition
 Overview
 --------
 
-Flamethrower is a small, fast, configurable tool for functional testing, benchmarking, and stress testing DNS servers and networks. It supports IPv4, IPv6, UDP and TCP, and has a modular system for generating queries used in the tests.
+Flamethrower is a small, fast, configurable tool for functional testing, benchmarking, and stress testing DNS servers and networks. It supports IPv4, IPv6, UDP, TCP, TCPTLS, QUIC and has a modular system for generating queries used in the tests.
 
 It was built as an alternative to dnsperf (https://nominum.com/measurement-tools/), and many of the command line options are compatible. 
 
@@ -25,6 +25,7 @@ Dependencies
 * libuv >= 1.23.0
 * libldns >= 1.7.0
 * gnutls >= 3.3
+* quicly 
 * C++ compiler supporting C++17
 
 Build

--- a/README.md
+++ b/README.md
@@ -15,8 +15,6 @@ Overview
 
 Flamethrower is a small, fast, configurable tool for functional testing, benchmarking, and stress testing DNS servers and networks. It supports IPv4, IPv6, UDP, TCP, TCPTLS, QUIC and has a modular system for generating queries used in the tests.
 
-It was built as an alternative to dnsperf (https://nominum.com/measurement-tools/), and many of the command line options are compatible. 
-
 Dependencies
 ------------
 
@@ -25,16 +23,39 @@ Dependencies
 * libuv >= 1.23.0
 * libldns >= 1.7.0
 * gnutls >= 3.3
-* quicly 
 * C++ compiler supporting C++17
 
 Build
 -----
 
-CMake based, required libuv and ldns.
+CMake based build, requires dependencies above. You may need to set PKG_CONFIG_PATH to help locate the dependencies.
 ```
 mkdir build; cd build
 cmake ..
+make
+```
+
+Experimental support is included for DNS-over-QUIC, following the draft RFC https://datatracker.ietf.org/doc/draft-huitema-quic-dnsoquic/
+DoQ requires additional dependencies:
+ * quicly https://github.com/h2o/quicly
+ * openssl >= 1.0.2
+ 
+To build with DoQ support, first checkout and build quicly:
+```
+git clone https://github.com/h2o/quicly.git
+cd quicly
+git submodule update --init --recursive
+mkdir build; cd build
+cmake ..
+make
+```
+the name of the "build" directory used to build quicly is significant, as it's referenced in the flamethrower paths.
+You then need to manually symlink quicly into the flamethrower 3rd party directory before enabling support in flamethrower and building:
+```
+cd flamethrower
+ln -s <PATH-TO-QUICLY> 3rd/
+mkdir build; cd build
+cmake -DQUIC_ENABLE=ON ..
 make
 ```
 

--- a/ci/install-quicly.sh
+++ b/ci/install-quicly.sh
@@ -10,6 +10,10 @@ cd quicly
 
 # instructions from quicly README
 git submodule update --init --recursive
+if ["$TRAVIS_OS_NAME" == "osx"]
+then
+    export PKG_CONFIG_PATH=/usr/local/opt/openssl@1.1/lib/pkgconfig
+fi
 cmake .
 make
 

--- a/ci/install-quicly.sh
+++ b/ci/install-quicly.sh
@@ -10,7 +10,7 @@ cd quicly
 
 # instructions from quicly README
 git submodule update --init --recursive
-if ["$TRAVIS_OS_NAME" == "osx"]
+if [ "$TRAVIS_OS_NAME" = "osx" ];
 then
     export PKG_CONFIG_PATH=/usr/local/opt/openssl@1.1/lib/pkgconfig
 fi

--- a/ci/install-quicly.sh
+++ b/ci/install-quicly.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+GITREPO="https://github.com/h2o/quicly"
+
+set -ex
+
+cd /tmp
+git clone "$GITREPO"
+cd quicly
+
+# instructions from quicly README
+git submodule update --init --recursive
+cmake .
+make
+

--- a/ci/install-quicly.sh
+++ b/ci/install-quicly.sh
@@ -8,12 +8,12 @@ cd /tmp
 git clone "$GITREPO"
 cd quicly
 
-# instructions from quicly README
 git submodule update --init --recursive
 if [ "$TRAVIS_OS_NAME" = "osx" ];
 then
     export PKG_CONFIG_PATH=/usr/local/opt/openssl@1.1/lib/pkgconfig
 fi
-cmake .
+mkdir build && cd build
+cmake ..
 make
 

--- a/flame/flame.h.in
+++ b/flame/flame.h.in
@@ -1,0 +1,3 @@
+#cmakedefine QUIC_ENABLE
+#cmakedefine FLAME_VERSION_NUM "@PROJECT_VERSION@"
+#cmakedefine FLAME_VERSION "@FLAME_VERSION@"

--- a/flame/main.cpp
+++ b/flame/main.cpp
@@ -17,7 +17,7 @@
 
 #include <uvw.hpp>
 
-#include "version.h"
+#include "flame.h"
 
 static const char USAGE[] =
     R"(Flamethrower.
@@ -184,10 +184,20 @@ int main(int argc, char *argv[])
             c_count = 30;
     } else if (args["-P"].asString() == "udp") {
         proto = Protocol::UDP;
-    } else if (args["-P"].asString() == "quic") {
+    }
+#ifdef QUIC_ENABLE
+    else if (args["-P"].asString() == "quic") {
         proto = Protocol::QUIC;
-    } else {
-        std::cerr << "protocol must be 'udp', 'quic', 'tcp' or 'tcptls'" << std::endl;
+    }
+#endif
+    else {
+        std::cerr << "protocol must be 'udp', 'tcp', 'tcptls'";
+#ifdef QUIC_ENABLE
+        std::cerr << ", 'quic'";
+#else
+        std::cerr << " (quic support is disabled)";
+#endif
+        std::cerr << std::endl;
         return 1;
     }
 
@@ -195,9 +205,11 @@ int main(int argc, char *argv[])
         if (proto == Protocol::TCPTLS) {
             args["-p"] = std::string("853");
         }
+#ifdef QUIC_ENABLE
         else if (proto == Protocol::QUIC) {
             args["-p"] = std::string("784");
         }
+#endif
         else {
             args["-p"] = std::string("53");
         }

--- a/flame/main.cpp
+++ b/flame/main.cpp
@@ -314,7 +314,7 @@ int main(int argc, char *argv[])
     traf_config->s_delay = s_delay;
     traf_config->protocol = proto;
     traf_config->r_timeout = args["-t"].asLong();
-    std::memcpy(&traf_config->sa, node->ai_addr, node->ai_addrlen);
+    memcpy(&traf_config->sa, node->ai_addr, node->ai_addrlen);
     traf_config->salen = node->ai_addrlen;
 
     std::vector<std::shared_ptr<TrafGen>> throwers;

--- a/flame/main.cpp
+++ b/flame/main.cpp
@@ -306,6 +306,8 @@ int main(int argc, char *argv[])
     traf_config->s_delay = s_delay;
     traf_config->protocol = proto;
     traf_config->r_timeout = args["-t"].asLong();
+    std::memcpy(&traf_config->sa, node->ai_addr, node->ai_addrlen);
+    traf_config->salen = node->ai_addrlen;
 
     std::vector<std::shared_ptr<TrafGen>> throwers;
     for (auto i = 0; i < c_count; i++) {

--- a/flame/main.cpp
+++ b/flame/main.cpp
@@ -19,6 +19,9 @@
 
 #include "version.h"
 
+#include "quicly.h"
+#include "quicly/streambuf.h"
+
 static const char USAGE[] =
     R"(Flamethrower.
     Usage:
@@ -47,7 +50,7 @@ static const char USAGE[] =
       -f FILE          Read records from FILE, one per row, QNAME TYPE
       -p PORT          Which port to flame [defaults: 53, 853 for tcptls]
       -F FAMILY        Internet family (inet/inet6) [default: inet]
-      -P PROTOCOL      Protocol to use (udp/tcp/tcptls) [default: udp]
+      -P PROTOCOL      Protocol to use (udp/tcp/tcptls/quic) [default: udp]
       -g GENERATOR     Generate queries with the given generator [default: static]
       -o FILE          Metrics output file, JSON format.
       -v VERBOSITY     How verbose output should be, 0 is silent [default: 1]
@@ -96,6 +99,37 @@ static const char USAGE[] =
         flame target.test.com -T ANY -g randomlabel lblsize=10 lblcount=4 count=1000
 
 )";
+
+/**
+ * the QUIC context
+ */
+static quicly_context_t ctx;
+/**
+ * CID seed
+ */
+static quicly_cid_plaintext_t next_cid;
+
+static int read_stdin(quicly_conn_t *conn)
+{
+    quicly_stream_t *stream0;
+    char buf[4096];
+    size_t rret;
+
+    if ((stream0 = quicly_get_stream(conn, 0)) == NULL || !quicly_sendstate_is_open(&stream0->sendstate))
+        return 0;
+
+    while ((rret = read(0, buf, sizeof(buf))) == -1 && errno == EINTR)
+        ;
+    if (rret == 0) {
+        /* stdin closed, close the send-side of stream0 */
+        quicly_streambuf_egress_shutdown(stream0);
+        return 0;
+    } else {
+        /* write data to send buffer */
+        quicly_streambuf_egress_write(stream0, buf, rret);
+        return 1;
+    }
+}
 
 void parse_flowspec(std::string spec, std::queue<std::pair<uint64_t, uint64_t>> &result, int verbosity)
 {
@@ -146,6 +180,131 @@ bool arg_exists(const char *needle, int argc, char *argv[])
     return false;
 }
 
+static void process_msg(quicly_conn_t **conn, struct msghdr *msg, size_t dgram_len)
+{
+    size_t off, packet_len;
+
+    /* split UDP datagram into multiple QUIC packets */
+    for (off = 0; off < dgram_len; off += packet_len) {
+        quicly_decoded_packet_t decoded;
+        if ((packet_len = quicly_decode_packet(&ctx, &decoded, (uint8_t*)msg->msg_iov[0].iov_base + off, dgram_len - off)) == SIZE_MAX)
+            return;
+        /* TODO match incoming packets to connections, handle version negotiation, rebinding, retry, etc. */
+        if (*conn != NULL) {
+            /* let the current connection handle ingress packets */
+            quicly_receive(*conn, &decoded);
+        } else {
+            /* assume that the packet is a new connection */
+            quicly_accept(conn, &ctx, (struct sockaddr*)msg->msg_name, msg->msg_namelen, &decoded, ptls_iovec_init(NULL, 0), &next_cid, NULL);
+        }
+    }
+}
+
+static int send_one(int fd, quicly_datagram_t *p)
+{
+    struct iovec vec = {.iov_base = p->data.base, .iov_len = p->data.len};
+    struct msghdr mess = {.msg_name = &p->sa, .msg_namelen = p->salen, .msg_iov = &vec, .msg_iovlen = 1};
+    int ret;
+
+    while ((ret = (int)sendmsg(fd, &mess, 0)) == -1 && errno == EINTR)
+        ;
+    return ret;
+}
+
+static int run_loop(int fd, quicly_conn_t *conn, int (*stdin_read_cb)(quicly_conn_t *conn))
+{
+    while (1) {
+
+        /* wait for sockets to become readable, or some event in the QUIC stack to fire */
+        fd_set readfds;
+        struct timeval *tv, tvbuf;
+        do {
+            if (conn != NULL) {
+                int64_t timeout_msec = quicly_get_first_timeout(conn) - ctx.now->cb(ctx.now);
+                if (timeout_msec <= 0) {
+                    tvbuf.tv_sec = 0;
+                    tvbuf.tv_usec = 0;
+                } else {
+                    tvbuf.tv_sec = timeout_msec / 1000;
+                    tvbuf.tv_usec = timeout_msec % 1000 * 1000;
+                }
+                tv = &tvbuf;
+            } else {
+                tv = NULL;
+            }
+            FD_ZERO(&readfds);
+            FD_SET(fd, &readfds);
+            /* we want to read input from stdin */
+            if (stdin_read_cb != NULL)
+                FD_SET(0, &readfds);
+        } while (select(fd + 1, &readfds, NULL, NULL, tv) == -1 && errno == EINTR);
+
+        /* read the QUIC fd */
+        if (FD_ISSET(fd, &readfds)) {
+            uint8_t buf[4096];
+            struct sockaddr_storage sa;
+            struct iovec vec = {.iov_base = buf, .iov_len = sizeof(buf)};
+            struct msghdr msg = {.msg_name = &sa, .msg_namelen = sizeof(sa), .msg_iov = &vec, .msg_iovlen = 1};
+            ssize_t rret;
+            while ((rret = recvmsg(fd, &msg, 0)) <= 0 && errno == EINTR)
+                ;
+            if (rret > 0)
+                process_msg(&conn, &msg, rret);
+        }
+
+        /* read stdin, send the input to the active stram */
+        if (FD_ISSET(0, &readfds)) {
+            assert(stdin_read_cb != NULL);
+            if (!(*stdin_read_cb)(conn))
+                stdin_read_cb = NULL;
+        }
+
+        /* send QUIC packets, if any */
+        if (conn != NULL) {
+            quicly_datagram_t *dgrams[16];
+            size_t num_dgrams = sizeof(dgrams) / sizeof(dgrams[0]);
+            int ret = quicly_send(conn, dgrams, &num_dgrams);
+            switch (ret) {
+                case 0: {
+                    size_t i;
+                    for (i = 0; i != num_dgrams; ++i) {
+                        send_one(fd, dgrams[i]);
+                        ctx.packet_allocator->free_packet(ctx.packet_allocator, dgrams[i]);
+                    }
+                } break;
+                case QUICLY_ERROR_FREE_CONNECTION:
+                    /* connection has been closed, free, and exit when running as a client */
+                    quicly_free(conn);
+                    conn = NULL;
+                    return 0;
+                default:
+                    fprintf(stderr, "quicly_send returned %d\n", ret);
+                    return 1;
+            }
+        }
+    }
+
+    return 0;
+}
+
+static int run_client(int fd, const char *host, struct sockaddr *sa, socklen_t salen)
+{
+    quicly_conn_t *conn;
+    int ret;
+
+    /* initiate a connection, and open a stream */
+    if ((ret = quicly_connect(&conn, &ctx, host, sa, salen, &next_cid, NULL, NULL)) != 0) {
+        fprintf(stderr, "quicly_connect failed:%d\n", ret);
+        return 1;
+    }
+    quicly_stream_t *stream; /* we retain the opened stream via the on_stream_open callback */
+    quicly_open_stream(conn, &stream, 0);
+
+    /* enter the event loop with a connection object */
+    return run_loop(fd, conn, read_stdin);
+}
+
+
 int main(int argc, char *argv[])
 {
 
@@ -188,16 +347,23 @@ int main(int argc, char *argv[])
             c_count = 30;
     } else if (args["-P"].asString() == "udp") {
         proto = Protocol::UDP;
+    } else if (args["-P"].asString() == "quic") {
+        proto = Protocol::QUIC;
     } else {
-        std::cerr << "protocol must be 'udp', 'tcp' or 'tcptls'" << std::endl;
+        std::cerr << "protocol must be 'udp', 'quic', 'tcp' or 'tcptls'" << std::endl;
         return 1;
     }
 
     if (!args["-p"]) {
-        if (proto == Protocol::TCPTLS)
+        if (proto == Protocol::TCPTLS) {
             args["-p"] = std::string("853");
-        else
+        }
+        else if (proto == Protocol::QUIC) {
+            args["-p"] = std::string("784");
+        }
+        else {
             args["-p"] = std::string("53");
+        }
     }
 
     auto runtime_limit = args["-l"].asLong();

--- a/flame/main.cpp
+++ b/flame/main.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017 NSONE, Inc
+// Copyright 2017-2019 NSONE, Inc
 
 #include <iostream>
 #include <iterator>
@@ -19,17 +19,10 @@
 
 #include "version.h"
 
-#include "quicly.h"
-#include "quicly/streambuf.h"
-
 static const char USAGE[] =
     R"(Flamethrower.
     Usage:
-      flame [-q QCOUNT] [-c TCOUNT] [-p PORT] [-d DELAY_MS] [-r RECORD] [-T QTYPE] [-o FILE]
-            [-l LIMIT_SECS] [-t TIMEOUT] [-F FAMILY] [-f FILE] [-n LOOP] [-P PROTOCOL]
-            [-Q QPS] [-g GENERATOR] [-v VERBOSITY] [-R] [--class CLASS] [--qps-flow SPEC]
-            [--dnssec]
-            TARGET [GENOPTS]...
+      flame [options] TARGET [GENOPTS]...
       flame (-h | --help)
       flame --version
 
@@ -55,7 +48,9 @@ static const char USAGE[] =
       -o FILE          Metrics output file, JSON format.
       -v VERBOSITY     How verbose output should be, 0 is silent [default: 1]
       -R               Randomize the query list before sending [default: false]
-      --dnssec         Set DO flag in EDNS.
+      --dnssec         Set DO flag in EDNS
+      --chain          Certificate chain file (PEM format)
+      --private        Private key file (PEM format)
 
      Generators:
 
@@ -99,37 +94,6 @@ static const char USAGE[] =
         flame target.test.com -T ANY -g randomlabel lblsize=10 lblcount=4 count=1000
 
 )";
-
-/**
- * the QUIC context
- */
-static quicly_context_t ctx;
-/**
- * CID seed
- */
-static quicly_cid_plaintext_t next_cid;
-
-static int read_stdin(quicly_conn_t *conn)
-{
-    quicly_stream_t *stream0;
-    char buf[4096];
-    size_t rret;
-
-    if ((stream0 = quicly_get_stream(conn, 0)) == NULL || !quicly_sendstate_is_open(&stream0->sendstate))
-        return 0;
-
-    while ((rret = read(0, buf, sizeof(buf))) == -1 && errno == EINTR)
-        ;
-    if (rret == 0) {
-        /* stdin closed, close the send-side of stream0 */
-        quicly_streambuf_egress_shutdown(stream0);
-        return 0;
-    } else {
-        /* write data to send buffer */
-        quicly_streambuf_egress_write(stream0, buf, rret);
-        return 1;
-    }
-}
 
 void parse_flowspec(std::string spec, std::queue<std::pair<uint64_t, uint64_t>> &result, int verbosity)
 {
@@ -180,129 +144,6 @@ bool arg_exists(const char *needle, int argc, char *argv[])
     return false;
 }
 
-static void process_msg(quicly_conn_t **conn, struct msghdr *msg, size_t dgram_len)
-{
-    size_t off, packet_len;
-
-    /* split UDP datagram into multiple QUIC packets */
-    for (off = 0; off < dgram_len; off += packet_len) {
-        quicly_decoded_packet_t decoded;
-        if ((packet_len = quicly_decode_packet(&ctx, &decoded, (uint8_t*)msg->msg_iov[0].iov_base + off, dgram_len - off)) == SIZE_MAX)
-            return;
-        /* TODO match incoming packets to connections, handle version negotiation, rebinding, retry, etc. */
-        if (*conn != NULL) {
-            /* let the current connection handle ingress packets */
-            quicly_receive(*conn, &decoded);
-        } else {
-            /* assume that the packet is a new connection */
-            quicly_accept(conn, &ctx, (struct sockaddr*)msg->msg_name, msg->msg_namelen, &decoded, ptls_iovec_init(NULL, 0), &next_cid, NULL);
-        }
-    }
-}
-
-static int send_one(int fd, quicly_datagram_t *p)
-{
-    struct iovec vec = {.iov_base = p->data.base, .iov_len = p->data.len};
-    struct msghdr mess = {.msg_name = &p->sa, .msg_namelen = p->salen, .msg_iov = &vec, .msg_iovlen = 1};
-    int ret;
-
-    while ((ret = (int)sendmsg(fd, &mess, 0)) == -1 && errno == EINTR)
-        ;
-    return ret;
-}
-
-static int run_loop(int fd, quicly_conn_t *conn, int (*stdin_read_cb)(quicly_conn_t *conn))
-{
-    while (1) {
-
-        /* wait for sockets to become readable, or some event in the QUIC stack to fire */
-        fd_set readfds;
-        struct timeval *tv, tvbuf;
-        do {
-            if (conn != NULL) {
-                int64_t timeout_msec = quicly_get_first_timeout(conn) - ctx.now->cb(ctx.now);
-                if (timeout_msec <= 0) {
-                    tvbuf.tv_sec = 0;
-                    tvbuf.tv_usec = 0;
-                } else {
-                    tvbuf.tv_sec = timeout_msec / 1000;
-                    tvbuf.tv_usec = timeout_msec % 1000 * 1000;
-                }
-                tv = &tvbuf;
-            } else {
-                tv = NULL;
-            }
-            FD_ZERO(&readfds);
-            FD_SET(fd, &readfds);
-            /* we want to read input from stdin */
-            if (stdin_read_cb != NULL)
-                FD_SET(0, &readfds);
-        } while (select(fd + 1, &readfds, NULL, NULL, tv) == -1 && errno == EINTR);
-
-        /* read the QUIC fd */
-        if (FD_ISSET(fd, &readfds)) {
-            uint8_t buf[4096];
-            struct sockaddr_storage sa;
-            struct iovec vec = {.iov_base = buf, .iov_len = sizeof(buf)};
-            struct msghdr msg = {.msg_name = &sa, .msg_namelen = sizeof(sa), .msg_iov = &vec, .msg_iovlen = 1};
-            ssize_t rret;
-            while ((rret = recvmsg(fd, &msg, 0)) <= 0 && errno == EINTR)
-                ;
-            if (rret > 0)
-                process_msg(&conn, &msg, rret);
-        }
-
-        /* read stdin, send the input to the active stram */
-        if (FD_ISSET(0, &readfds)) {
-            assert(stdin_read_cb != NULL);
-            if (!(*stdin_read_cb)(conn))
-                stdin_read_cb = NULL;
-        }
-
-        /* send QUIC packets, if any */
-        if (conn != NULL) {
-            quicly_datagram_t *dgrams[16];
-            size_t num_dgrams = sizeof(dgrams) / sizeof(dgrams[0]);
-            int ret = quicly_send(conn, dgrams, &num_dgrams);
-            switch (ret) {
-                case 0: {
-                    size_t i;
-                    for (i = 0; i != num_dgrams; ++i) {
-                        send_one(fd, dgrams[i]);
-                        ctx.packet_allocator->free_packet(ctx.packet_allocator, dgrams[i]);
-                    }
-                } break;
-                case QUICLY_ERROR_FREE_CONNECTION:
-                    /* connection has been closed, free, and exit when running as a client */
-                    quicly_free(conn);
-                    conn = NULL;
-                    return 0;
-                default:
-                    fprintf(stderr, "quicly_send returned %d\n", ret);
-                    return 1;
-            }
-        }
-    }
-
-    return 0;
-}
-
-static int run_client(int fd, const char *host, struct sockaddr *sa, socklen_t salen)
-{
-    quicly_conn_t *conn;
-    int ret;
-
-    /* initiate a connection, and open a stream */
-    if ((ret = quicly_connect(&conn, &ctx, host, sa, salen, &next_cid, NULL, NULL)) != 0) {
-        fprintf(stderr, "quicly_connect failed:%d\n", ret);
-        return 1;
-    }
-    quicly_stream_t *stream; /* we retain the opened stream via the on_stream_open callback */
-    quicly_open_stream(conn, &stream, 0);
-
-    /* enter the event loop with a connection object */
-    return run_loop(fd, conn, read_stdin);
-}
 
 
 int main(int argc, char *argv[])

--- a/flame/main.cpp
+++ b/flame/main.cpp
@@ -15,6 +15,9 @@
 #include "trafgen.h"
 #include "utils.h"
 
+#include "picotls.h"
+#include "picotls/openssl.h"
+
 #include <uvw.hpp>
 
 #include "version.h"
@@ -49,8 +52,6 @@ static const char USAGE[] =
       -v VERBOSITY     How verbose output should be, 0 is silent [default: 1]
       -R               Randomize the query list before sending [default: false]
       --dnssec         Set DO flag in EDNS
-      --chain          Certificate chain file (PEM format)
-      --private        Private key file (PEM format)
 
      Generators:
 
@@ -144,7 +145,56 @@ bool arg_exists(const char *needle, int argc, char *argv[])
     return false;
 }
 
+int q_on_stop_sending(quicly_stream_t *stream, int err)
+{
+    fprintf(stderr, "received STOP_SENDING: %" PRIu16 "\n", QUICLY_ERROR_GET_ERROR_CODE(err));
+    quicly_close(stream->conn, QUICLY_ERROR_FROM_APPLICATION_ERROR_CODE(0), "");
+    return 0;
+}
 
+int q_on_receive_reset(quicly_stream_t *stream, int err)
+{
+    fprintf(stderr, "received RESET_STREAM: %" PRIu16 "\n", QUICLY_ERROR_GET_ERROR_CODE(err));
+    quicly_close(stream->conn, QUICLY_ERROR_FROM_APPLICATION_ERROR_CODE(0), "");
+    return 0;
+}
+
+int q_on_receive(quicly_stream_t *stream, size_t off, const void *src, size_t len)
+{
+    int ret;
+
+    /* read input to receive buffer */
+    if ((ret = quicly_streambuf_ingress_receive(stream, off, src, len)) != 0)
+        return ret;
+
+    /* obtain contiguous bytes from the receive buffer */
+    ptls_iovec_t input = quicly_streambuf_ingress_get(stream);
+
+    /* client: print to stdout */
+    fwrite(input.base, 1, input.len, stdout);
+    fflush(stdout);
+    /* initiate connection close after receiving all data */
+    if (quicly_recvstate_transfer_complete(&stream->recvstate))
+        quicly_close(stream->conn, 0, "");
+
+    /* remove used bytes from receive buffer */
+    quicly_streambuf_ingress_shift(stream, input.len);
+
+    return 0;
+}
+
+int q_on_stream_open(quicly_stream_open_t *self, quicly_stream_t *stream)
+{
+    static const quicly_stream_callbacks_t stream_callbacks = {
+        quicly_streambuf_destroy, quicly_streambuf_egress_shift, quicly_streambuf_egress_emit, q_on_stop_sending, q_on_receive,
+        q_on_receive_reset};
+    int ret;
+
+    if ((ret = quicly_streambuf_create(stream, sizeof(quicly_streambuf_t))) != 0)
+        return ret;
+    stream->callbacks = &stream_callbacks;
+    return 0;
+}
 
 int main(int argc, char *argv[])
 {
@@ -308,6 +358,19 @@ int main(int argc, char *argv[])
     traf_config->r_timeout = args["-t"].asLong();
     std::memcpy(&traf_config->sa, node->ai_addr, node->ai_addrlen);
     traf_config->salen = node->ai_addrlen;
+
+    // quic
+    ptls_context_t tlsctx = {
+        .random_bytes = ptls_openssl_random_bytes,
+        .get_time = &ptls_get_time,
+        .key_exchanges = ptls_openssl_key_exchanges,
+        .cipher_suites = ptls_openssl_cipher_suites,
+    };
+    quicly_stream_open_t stream_open = {q_on_stream_open};
+    traf_config->q_ctx = quicly_default_context;
+    traf_config->q_ctx.tls = &tlsctx;
+    quicly_amend_ptls_context(traf_config->q_ctx.tls);
+    traf_config->q_ctx.stream_open = &stream_open;
 
     std::vector<std::shared_ptr<TrafGen>> throwers;
     for (auto i = 0; i < c_count; i++) {

--- a/flame/metrics.cpp
+++ b/flame/metrics.cpp
@@ -6,7 +6,7 @@
 
 #include "json.hpp"
 #include "metrics.h"
-#include "version.h"
+#include "flame.h"
 
 #include <ldns/util.h>
 

--- a/flame/trafgen.cpp
+++ b/flame/trafgen.cpp
@@ -11,6 +11,8 @@
 #include <picotls.h>
 #include <picotls/openssl.h>
 
+#include <quicly/defaults.h>
+
 #include <ldns/rbtree.h>
 
 #include <ldns/host2wire.h>

--- a/flame/trafgen.cpp
+++ b/flame/trafgen.cpp
@@ -382,8 +382,6 @@ static int q_on_receive(quicly_stream_t *stream, size_t off, const void *src, si
 {
     int ret;
 
-    std::cout << "STREAM RECEIVE" << std::endl;
-
     /* read input to receive buffer */
     if ((ret = quicly_streambuf_ingress_receive(stream, off, src, len)) != 0)
         return ret;
@@ -391,9 +389,6 @@ static int q_on_receive(quicly_stream_t *stream, size_t off, const void *src, si
     /* obtain contiguous bytes from the receive buffer */
     ptls_iovec_t input = quicly_streambuf_ingress_get(stream);
 
-    /* client: print to stdout */
-    fwrite(input.base, 1, input.len, stdout);
-    fflush(stdout);
     /* initiate connection close after receiving all data */
     if (quicly_recvstate_transfer_complete(&stream->recvstate))
         quicly_close(stream->conn, 0, "");
@@ -554,7 +549,6 @@ void TrafGen::q_process_msg(quicly_conn_t *conn, const uint8_t *src, size_t dgra
     size_t off, packet_len;
     assert(conn);
 
-    std::cerr << "QUIC PROCESS MSG" << std::endl;
     /* split UDP datagram into multiple QUIC packets */
     for (off = 0; off < dgram_len; off += packet_len) {
         quicly_decoded_packet_t decoded;

--- a/flame/trafgen.cpp
+++ b/flame/trafgen.cpp
@@ -289,6 +289,40 @@ void TrafGen::udp_send()
     }
 }
 
+void TrafGen::start_quic()
+{
+
+    // XXX copied from start_udp
+    _udp_handle = _loop->resource<uvw::UDPHandle>(_traf_config->family);
+
+    _udp_handle->on<uvw::ErrorEvent>([this](const uvw::ErrorEvent &e, uvw::UDPHandle &) {
+        _metrics->net_error();
+    });
+
+    if (_traf_config->family == AF_INET) {
+        _udp_handle->bind<uvw::IPv4>("0.0.0.0", 0);
+    } else {
+        _udp_handle->bind<uvw::IPv6>("::0", 0, uvw::UDPHandle::Bind::IPV6ONLY);
+    }
+
+    _metrics->trafgen_id(_udp_handle->sock().port);
+
+    int ret;
+    if ((ret = quicly_connect(&q_conn, &_traf_config->q_ctx, _traf_config->target_address.data(),
+                              (struct sockaddr*)&_traf_config->sa, _traf_config->salen, &q_next_cid, NULL, NULL)) != 0) {
+        throw std::runtime_error("quicly connect failed: " + std::to_string(ret));
+    }
+    quicly_stream_t *stream; /* we retain the opened stream via the on_stream_open callback */
+    quicly_open_stream(q_conn, &stream, 0);
+
+    _udp_handle->on<uvw::UDPDataEvent>([this](const uvw::UDPDataEvent &event, uvw::UDPHandle &h) {
+        q_process_msg(q_conn, (const uint8_t*)event.data.get(), event.length);
+    });
+
+    _udp_handle->recv();
+
+}
+
 void TrafGen::start()
 {
 
@@ -296,13 +330,11 @@ void TrafGen::start()
         start_udp();
         _sender_timer = _loop->resource<uvw::TimerHandle>();
         _sender_timer->on<uvw::TimerEvent>([this](const uvw::TimerEvent &event, uvw::TimerHandle &h) {
-            if (_traf_config->protocol == Protocol::UDP) {
-                udp_send();
-            } else if (_traf_config->protocol == Protocol::TCP || _traf_config->protocol == Protocol::TCPTLS) {
-                start_tcp_session();
-            }
+            udp_send();
         });
         _sender_timer->start(uvw::TimerHandle::Time{1}, uvw::TimerHandle::Time{_traf_config->s_delay});
+    } else if (_traf_config->protocol == Protocol::QUIC) {
+        start_quic();
     } else {
         start_tcp_session();
     }
@@ -373,23 +405,19 @@ void TrafGen::stop()
 
 }
 
-void TrafGen::q_process_msg(quicly_conn_t **conn, struct msghdr *msg, size_t dgram_len)
+void TrafGen::q_process_msg(quicly_conn_t *conn, const uint8_t *src, size_t dgram_len)
 {
     size_t off, packet_len;
 
     /* split UDP datagram into multiple QUIC packets */
     for (off = 0; off < dgram_len; off += packet_len) {
         quicly_decoded_packet_t decoded;
-        if ((packet_len = quicly_decode_packet(&ctx, &decoded, (uint8_t*)msg->msg_iov[0].iov_base + off, dgram_len - off)) == SIZE_MAX)
+        if ((packet_len = quicly_decode_packet(&_traf_config->q_ctx, &decoded, src, dgram_len - off)) == SIZE_MAX)
             return;
         /* TODO match incoming packets to connections, handle version negotiation, rebinding, retry, etc. */
-        if (*conn != NULL) {
-            /* let the current connection handle ingress packets */
-            quicly_receive(*conn, &decoded);
-        } else {
-            /* assume that the packet is a new connection */
-            quicly_accept(conn, &ctx, (struct sockaddr*)msg->msg_name, msg->msg_namelen, &decoded, ptls_iovec_init(NULL, 0), &next_cid, NULL);
-        }
+        assert(conn);
+        /* let the current connection handle ingress packets */
+        quicly_receive(conn, &decoded);
     }
 }
 
@@ -406,76 +434,42 @@ int TrafGen::q_send_one(int fd, quicly_datagram_t *p)
 
 int TrafGen::q_run_loop(int fd, quicly_conn_t *conn, int (*stdin_read_cb)(quicly_conn_t *conn))
 {
-    while (1) {
-
-        /* wait for sockets to become readable, or some event in the QUIC stack to fire */
-        fd_set readfds;
-        struct timeval *tv, tvbuf;
-        do {
-            if (conn != NULL) {
-                int64_t timeout_msec = quicly_get_first_timeout(conn) - ctx.now->cb(ctx.now);
-                if (timeout_msec <= 0) {
-                    tvbuf.tv_sec = 0;
-                    tvbuf.tv_usec = 0;
-                } else {
-                    tvbuf.tv_sec = timeout_msec / 1000;
-                    tvbuf.tv_usec = timeout_msec % 1000 * 1000;
-                }
-                tv = &tvbuf;
-            } else {
-                tv = NULL;
-            }
-            FD_ZERO(&readfds);
-            FD_SET(fd, &readfds);
-            /* we want to read input from stdin */
-            if (stdin_read_cb != NULL)
-                FD_SET(0, &readfds);
-        } while (select(fd + 1, &readfds, NULL, NULL, tv) == -1 && errno == EINTR);
-
         /* read the QUIC fd */
-        if (FD_ISSET(fd, &readfds)) {
-            uint8_t buf[4096];
-            struct sockaddr_storage sa;
-            struct iovec vec = {.iov_base = buf, .iov_len = sizeof(buf)};
-            struct msghdr msg = {.msg_name = &sa, .msg_namelen = sizeof(sa), .msg_iov = &vec, .msg_iovlen = 1};
-            ssize_t rret;
-            while ((rret = recvmsg(fd, &msg, 0)) <= 0 && errno == EINTR)
-                ;
-            if (rret > 0)
-                q_process_msg(&conn, &msg, rret);
-        }
-
-        /* read stdin, send the input to the active stram */
-        if (FD_ISSET(0, &readfds)) {
-            assert(stdin_read_cb != NULL);
-            if (!(*stdin_read_cb)(conn))
-                stdin_read_cb = NULL;
-        }
+//        if (FD_ISSET(fd, &readfds)) {
+//            uint8_t buf[4096];
+//            struct sockaddr_storage sa;
+//            struct iovec vec = {.iov_base = buf, .iov_len = sizeof(buf)};
+//            struct msghdr msg = {.msg_name = &sa, .msg_namelen = sizeof(sa), .msg_iov = &vec, .msg_iovlen = 1};
+//            ssize_t rret;
+//            while ((rret = recvmsg(fd, &msg, 0)) <= 0 && errno == EINTR)
+//                ;
+//            if (rret > 0)
+//                q_process_msg(&conn, &msg, rret);
+//        }
 
         /* send QUIC packets, if any */
-        if (conn != NULL) {
-            quicly_datagram_t *dgrams[16];
-            size_t num_dgrams = sizeof(dgrams) / sizeof(dgrams[0]);
-            int ret = quicly_send(conn, dgrams, &num_dgrams);
-            switch (ret) {
-                case 0: {
-                    size_t i;
-                    for (i = 0; i != num_dgrams; ++i) {
-                        q_send_one(fd, dgrams[i]);
-                        ctx.packet_allocator->free_packet(ctx.packet_allocator, dgrams[i]);
-                    }
-                } break;
-                case QUICLY_ERROR_FREE_CONNECTION:
-                    /* connection has been closed, free, and exit when running as a client */
-                    quicly_free(conn);
-                    conn = NULL;
-                    return 0;
-                default:
-                    fprintf(stderr, "quicly_send returned %d\n", ret);
-                    return 1;
-            }
-        }
-    }
+//        if (conn != NULL) {
+//            quicly_datagram_t *dgrams[16];
+//            size_t num_dgrams = sizeof(dgrams) / sizeof(dgrams[0]);
+//            int ret = quicly_send(conn, dgrams, &num_dgrams);
+//            switch (ret) {
+//                case 0: {
+//                    size_t i;
+//                    for (i = 0; i != num_dgrams; ++i) {
+//                        q_send_one(fd, dgrams[i]);
+//                        ctx.packet_allocator->free_packet(ctx.packet_allocator, dgrams[i]);
+//                    }
+//                } break;
+//                case QUICLY_ERROR_FREE_CONNECTION:
+//                    /* connection has been closed, free, and exit when running as a client */
+//                    quicly_free(conn);
+//                    conn = NULL;
+//                    return 0;
+//                default:
+//                    fprintf(stderr, "quicly_send returned %d\n", ret);
+//                    return 1;
+//            }
+//        }
 
     return 0;
 }
@@ -502,20 +496,4 @@ int TrafGen::q_read_stdin(quicly_conn_t *conn)
     }
 }
 
-int TrafGen::q_run_client(int fd, const char *host, struct sockaddr *sa, socklen_t salen)
-{
-    quicly_conn_t *conn;
-    int ret;
-
-    /* initiate a connection, and open a stream */
-    if ((ret = quicly_connect(&conn, &ctx, host, sa, salen, &next_cid, NULL, NULL)) != 0) {
-        fprintf(stderr, "quicly_connect failed:%d\n", ret);
-        return 1;
-    }
-    quicly_stream_t *stream; /* we retain the opened stream via the on_stream_open callback */
-    quicly_open_stream(conn, &stream, 0);
-
-    /* enter the event loop with a connection object */
-    return q_run_loop(fd, conn, nullptr);
-}
 

--- a/flame/trafgen.cpp
+++ b/flame/trafgen.cpp
@@ -8,8 +8,8 @@
 
 #include "trafgen.h"
 #include "tcptlssession.h"
-#include "picotls.h"
-#include "picotls/openssl.h"
+#include <picotls.h>
+#include <picotls/openssl.h>
 
 #include <ldns/rbtree.h>
 

--- a/flame/trafgen.cpp
+++ b/flame/trafgen.cpp
@@ -432,7 +432,7 @@ void TrafGen::start_quic()
         .cipher_suites = ptls_openssl_cipher_suites,
     };
     q_stream_open = {q_on_stream_open};
-    q_ctx = quicly_default_context;
+    q_ctx = quicly_spec_context;
     q_ctx.tls = &q_tlsctx;
     quicly_amend_ptls_context(q_ctx.tls);
     q_ctx.stream_open = &q_stream_open;

--- a/flame/trafgen.cpp
+++ b/flame/trafgen.cpp
@@ -288,6 +288,7 @@ void TrafGen::quic_send()
 
         /* write data to send buffer */
         quicly_streambuf_egress_write(stream, (void*)std::get<0>(qt).get(), std::get<1>(qt));
+        quicly_streambuf_egress_shutdown(stream);
         // ???
         // in UDP, this buffer gets freed by libuv after send. in quic, it gets copied internally to
         // quic datagram, so this can be freed immediately

--- a/flame/trafgen.cpp
+++ b/flame/trafgen.cpp
@@ -422,7 +422,7 @@ void TrafGen::start_quic()
 {
 
     // quic
-    ptls_context_t tlsctx = {
+    q_tlsctx = {
         .random_bytes = ptls_openssl_random_bytes,
         .get_time = &ptls_get_time,
         .key_exchanges = ptls_openssl_key_exchanges,
@@ -430,7 +430,7 @@ void TrafGen::start_quic()
     };
     q_stream_open = {q_on_stream_open};
     q_ctx = quicly_default_context;
-    q_ctx.tls = &tlsctx;
+    q_ctx.tls = &q_tlsctx;
     quicly_amend_ptls_context(q_ctx.tls);
     q_ctx.stream_open = &q_stream_open;
 

--- a/flame/trafgen.cpp
+++ b/flame/trafgen.cpp
@@ -443,10 +443,13 @@ void TrafGen::start_quic()
         _metrics->net_error();
     });
 
+    socklen_t salen{0};
     if (_traf_config->family == AF_INET) {
         _udp_handle->bind<uvw::IPv4>("0.0.0.0", 0);
+        salen = sizeof(sockaddr_in);
     } else {
         _udp_handle->bind<uvw::IPv6>("::0", 0, uvw::UDPHandle::Bind::IPV6ONLY);
+        salen = sizeof(sockaddr_in6);
     }
 
     _metrics->trafgen_id(_udp_handle->sock().port);
@@ -458,7 +461,7 @@ void TrafGen::start_quic()
     sa.ss_family = _traf_config->family;
     inet_pton(sa.ss_family, addr.data(), sa_ptr->sa_data);
     if ((ret = quicly_connect(&q_conn, &q_ctx, addr.data(),
-                              (struct sockaddr*)&sa, sa_ptr->sa_len, &q_next_cid, NULL, NULL)) != 0) {
+                              (struct sockaddr*)&sa, salen, &q_next_cid, NULL, NULL)) != 0) {
         throw std::runtime_error("quicly connect failed: " + std::to_string(ret));
     }
 

--- a/flame/trafgen.cpp
+++ b/flame/trafgen.cpp
@@ -309,7 +309,7 @@ void TrafGen::quic_send()
             for (i = 0; i != num_dgrams; ++i) {
                 // XXX libuv needs to own this since it frees async
                 char *data = (char*)std::malloc(dgrams[i]->data.len);
-                std::memcpy(data, dgrams[i]->data.base, dgrams[i]->data.len);
+                memcpy(data, dgrams[i]->data.base, dgrams[i]->data.len);
                 if (data == nullptr) {
                     throw std::runtime_error("unable to allocate datagram memory");
                 }

--- a/flame/trafgen.h
+++ b/flame/trafgen.h
@@ -34,7 +34,6 @@ struct TrafGenConfig {
     Protocol protocol{Protocol::UDP};
     struct sockaddr_storage sa;
     socklen_t salen;
-    quicly_context_t q_ctx;
 };
 
 class TrafGen
@@ -51,8 +50,6 @@ class TrafGen
     std::shared_ptr<uvw::TcpHandle> _tcp_handle;
     std::shared_ptr<TCPSession> _tcp_session;
 
-    quicly_conn_t *q_conn;
-
     std::shared_ptr<uvw::TimerHandle> _sender_timer;
     std::shared_ptr<uvw::TimerHandle> _timeout_timer;
     std::shared_ptr<uvw::TimerHandle> _shutdown_timer;
@@ -63,6 +60,8 @@ class TrafGen
     // a randomized list of query ids that are not currently in flight
     std::vector<uint16_t> _free_id_list;
 
+    quicly_conn_t *q_conn;
+    quicly_context_t q_ctx;
     quicly_cid_plaintext_t q_next_cid;
 
     bool _stopping;
@@ -74,12 +73,11 @@ class TrafGen
     void start_udp();
     void start_quic();
     void udp_send();
+    void quic_send();
 
     void start_tcp_session();
     void start_wait_timer_for_tcp_finish();
 
-    int q_run_client(int fd, const char *host, struct sockaddr *sa, socklen_t salen);
-    int q_run_loop(int fd, quicly_conn_t *conn, int (*stdin_read_cb)(quicly_conn_t *conn));
     int q_send_one(int fd, quicly_datagram_t *p);
     void q_process_msg(quicly_conn_t *conn, const uint8_t *src, size_t dgram_len);
     int q_read_stdin(quicly_conn_t *conn);

--- a/flame/trafgen.h
+++ b/flame/trafgen.h
@@ -11,6 +11,9 @@
 #include "query.h"
 #include "tcpsession.h"
 
+#include "quicly.h"
+#include "quicly/streambuf.h"
+
 #include <TokenBucket.h>
 #include <uvw.hpp>
 
@@ -45,6 +48,9 @@ class TrafGen
     std::shared_ptr<uvw::TcpHandle> _tcp_handle;
     std::shared_ptr<TCPSession> _tcp_session;
 
+    quicly_context_t ctx;
+    quicly_cid_plaintext_t next_cid;
+
     std::shared_ptr<uvw::TimerHandle> _sender_timer;
     std::shared_ptr<uvw::TimerHandle> _timeout_timer;
     std::shared_ptr<uvw::TimerHandle> _shutdown_timer;
@@ -66,6 +72,12 @@ class TrafGen
 
     void start_tcp_session();
     void start_wait_timer_for_tcp_finish();
+
+    int q_run_client(int fd, const char *host, struct sockaddr *sa, socklen_t salen);
+    int q_run_loop(int fd, quicly_conn_t *conn, int (*stdin_read_cb)(quicly_conn_t *conn));
+    int q_send_one(int fd, quicly_datagram_t *p);
+    void q_process_msg(quicly_conn_t **conn, struct msghdr *msg, size_t dgram_len);
+    int q_read_stdin(quicly_conn_t *conn);
 
 public:
     TrafGen(std::shared_ptr<uvw::Loop> l,

--- a/flame/trafgen.h
+++ b/flame/trafgen.h
@@ -61,6 +61,7 @@ class TrafGen
     std::vector<uint16_t> _free_id_list;
 
     quicly_conn_t *q_conn;
+    quicly_stream_open_t q_stream_open;
     quicly_context_t q_ctx;
     quicly_cid_plaintext_t q_next_cid;
 
@@ -78,9 +79,7 @@ class TrafGen
     void start_tcp_session();
     void start_wait_timer_for_tcp_finish();
 
-    int q_send_one(int fd, quicly_datagram_t *p);
     void q_process_msg(quicly_conn_t *conn, const uint8_t *src, size_t dgram_len);
-    int q_read_stdin(quicly_conn_t *conn);
 
 public:
     TrafGen(std::shared_ptr<uvw::Loop> l,

--- a/flame/trafgen.h
+++ b/flame/trafgen.h
@@ -18,6 +18,7 @@ enum class Protocol {
     UDP,
     TCP,
     TCPTLS,
+    QUIC,
 };
 
 struct TrafGenConfig {

--- a/flame/trafgen.h
+++ b/flame/trafgen.h
@@ -64,6 +64,7 @@ class TrafGen
     quicly_stream_open_t q_stream_open;
     quicly_context_t q_ctx;
     quicly_cid_plaintext_t q_next_cid;
+    ptls_context_t q_tlsctx;
 
     bool _stopping;
 

--- a/flame/version.h
+++ b/flame/version.h
@@ -1,2 +1,0 @@
-#define FLAME_VERSION_NUM "0.10.0"
-#define FLAME_VERSION "Flamethrower 0.10.0"


### PR DESCRIPTION
Implement DoQ according to the draft spec: https://datatracker.ietf.org/doc/draft-huitema-quic-dnsoquic/

Using Fastly's QUIC library https://github.com/h2o/quicly

- [x] First pass at integration
- [x] Make QUIC support optional at build time
- [x] Fix Travis-CI
- [ ] Cleanup XXX markers
- [ ] Add example to docs, pointing out QUIC proxy
- [ ] Check for mem leaks
