### PR TITLE
Add ability to send to multiple targets at once

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,11 @@ Flame target with random labels:
 flame target.test.com -g randomlabel lblsize=10 lblcount=4 count=1000
 ```
 
+Flame multiple target at once, reading the list from a file:
+```
+flame file --targets myresolvers.txt
+```
+
 Detailed Features
 -----------------
 

--- a/flame/main.cpp
+++ b/flame/main.cpp
@@ -34,6 +34,8 @@ static const char USAGE[] =
     they will be sent queries in a strict round robin fashion across all concurrent generators. All targets must
     share the same port, protocol, and internet family.
 
+    TARGET may also be the special value "file", in which case the --targets option needs to also be specified.
+
     Options:
       -h --help        Show this screen.
       --version        Show version.

--- a/flame/main.cpp
+++ b/flame/main.cpp
@@ -389,7 +389,7 @@ int main(int argc, char *argv[])
     sigterm->start(SIGTERM);
 
     if (config->verbosity()) {
-        std::cout << "flaming target " << args["TARGET"] << " (";
+        std::cout << "flaming target(s) [";
         for (uint i = 0; i < 3; i++) {
             std::cout << traf_config->target_address[i];
             if (i == traf_config->target_address.size()-1) {
@@ -400,9 +400,9 @@ int main(int argc, char *argv[])
             }
         }
         if (traf_config->target_address.size() > 3) {
-            std::cout << " and " << traf_config->target_address.size()-3 << " more";
+            std::cout << "and " << traf_config->target_address.size()-3 << " more";
         }
-        std::cout << ") on port "
+        std::cout << "] on port "
                   << args["-p"].asLong()
                   << " with " << c_count << " concurrent generators, each sending " << b_count
                   << " queries every " << s_delay << "ms on protocol " << args["-P"].asString()

--- a/flame/main.cpp
+++ b/flame/main.cpp
@@ -55,11 +55,11 @@ static const char USAGE[] =
       -F FAMILY        Internet family (inet/inet6) [default: inet]
       -P PROTOCOL      Protocol to use (udp/tcp/tcptls) [default: udp]
       -g GENERATOR     Generate queries with the given generator [default: static]
-      -o FILE          Metrics output file, JSON format.
+      -o FILE          Metrics output file, JSON format
       -v VERBOSITY     How verbose output should be, 0 is silent [default: 1]
       -R               Randomize the query list before sending [default: false]
       --targets FILE   Get the list of TARGETs from the given file, one line per host or IP
-      --dnssec         Set DO flag in EDNS.
+      --dnssec         Set DO flag in EDNS
 
      Generators:
 

--- a/flame/main.cpp
+++ b/flame/main.cpp
@@ -223,9 +223,9 @@ int main(int argc, char *argv[])
     std::vector<std::string> raw_target_list;
     if (args["TARGET"].asString() == "file" && args["--targets"]) {
         std::ifstream inFile(args["--targets"].asString());
-        if (!inFile) {
-            std::cerr << "couldn't open file:" << std::endl;
-            exit(1);
+        if (!inFile.is_open()) {
+            std::cerr << "couldn't open targets file: " << args["--targets"].asString() << std::endl;
+            return 1;
         }
 
         std::string line;
@@ -244,6 +244,9 @@ int main(int argc, char *argv[])
         auto target_resolved = request->addrInfoSync(raw_target_list[i], args["-p"].asString());
         if (!target_resolved.first) {
             std::cerr << "unable to resolve target address: " << raw_target_list[i] << std::endl;
+            if (raw_target_list[i] == "file") {
+                std::cerr << "(did you mean to include --targets?)" << std::endl;
+            }
             return 1;
         }
         addrinfo *node{target_resolved.second.get()};

--- a/flame/main.cpp
+++ b/flame/main.cpp
@@ -37,8 +37,8 @@ static const char USAGE[] =
     TARGET may also be the special value "file", in which case the --targets option needs to also be specified.
 
     Options:
-      -h --help        Show this screen.
-      --version        Show version.
+      -h --help        Show this screen
+      --version        Show version
       --class CLASS    Default query class, defaults to IN. May also be CH [default: IN]
       -c TCOUNT        Number of concurrent traffic generators per process [default: 10]
       -d DELAY_MS      ms delay between each traffic generator's query [default: 1]

--- a/flame/trafgen.cpp
+++ b/flame/trafgen.cpp
@@ -216,9 +216,9 @@ void TrafGen::start_tcp_session()
 
     // fires ConnectEvent when connected
     if (_traf_config->family == AF_INET) {
-        _tcp_handle->connect<uvw::IPv4>(_traf_config->target_address, _traf_config->port);
+        _tcp_handle->connect<uvw::IPv4>(_traf_config->next_target_address(), _traf_config->port);
     } else {
-        _tcp_handle->connect<uvw::IPv6>(_traf_config->target_address, _traf_config->port);
+        _tcp_handle->connect<uvw::IPv6>(_traf_config->next_target_address(), _traf_config->port);
     }
 }
 
@@ -276,11 +276,11 @@ void TrafGen::udp_send()
         assert(_in_flight.find(id) == _in_flight.end());
         auto qt = _qgen->next_udp(id);
         if (_traf_config->family == AF_INET) {
-            _udp_handle->send<uvw::IPv4>(_traf_config->target_address, _traf_config->port,
+            _udp_handle->send<uvw::IPv4>(_traf_config->next_target_address(), _traf_config->port,
                 std::move(std::get<0>(qt)),
                 std::get<1>(qt));
         } else {
-            _udp_handle->send<uvw::IPv6>(_traf_config->target_address, _traf_config->port,
+            _udp_handle->send<uvw::IPv6>(_traf_config->next_target_address(), _traf_config->port,
                 std::move(std::get<0>(qt)),
                 std::get<1>(qt));
         }

--- a/flame/trafgen.h
+++ b/flame/trafgen.h
@@ -21,13 +21,22 @@ enum class Protocol {
 };
 
 struct TrafGenConfig {
-    std::string target_address;
+    std::vector<std::string> target_address;
+    unsigned int _current_target{0};
     int family{0};
     unsigned int port{53};
     int r_timeout{3};
     long s_delay{1};
     long batch_count{10};
     Protocol protocol{Protocol::UDP};
+    const std::string& next_target_address()
+    {
+        const std::string& next = target_address[_current_target];
+        _current_target++;
+        if (_current_target >= target_address.size())
+            _current_target = 0;
+        return next;
+    }
 };
 
 class TrafGen


### PR DESCRIPTION
The TARGET command line option now supports comma separated list, or the special keyword "file" which, combined with --targets option, allows reading the list from a file.
