### PR TITLE
README: update CMake dependency to 3.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ It was built as an alternative to dnsperf (https://nominum.com/measurement-tools
 Dependencies
 ------------
 
-* CMake >= 3.5
+* CMake >= 3.8
 * Linux or OSX
 * libuv >= 1.23.0
 * libldns >= 1.7.0


### PR DESCRIPTION
Earlier versions of CMake don't support CMAKE_CXX_STANDARD 17 and fail
with:

target requires the language dialect “CXX17” (with compiler extensions),
but CMake does not know the compile flags to use to enable it