### PR TITLE
Flame requires explicit uv link

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,7 @@ target_include_directories(flamecore
 
 target_link_libraries(flamecore
         PRIVATE ${LIBUV_LDFLAGS}
+        PRIVATE ${LIBUV_LIBRARIES}
         PRIVATE ${LIBLDNS_LDFLAGS}
         PRIVATE ${LIBLDNS_LIBRARIES}
         PRIVATE ${LIBGNUTLS_LDFLAGS}
@@ -89,6 +90,8 @@ add_executable(flame
 
 target_link_libraries(flame
         PRIVATE flamecore
+        PRIVATE ${LIBUV_LDFLAGS}
+        PRIVATE ${LIBUV_LIBRARIES}
         )
 
 add_executable(tests


### PR DESCRIPTION
flame does not compile without it, since main.cpp is using uv_refs but
does not explicitly reference it itself.

Tried on Fedora 29.

```
$ rpm -q libuv ldns gcc cmake
libuv-1.30.1-1.fc29.x86_64
ldns-1.7.0-21.fc29.x86_64
gcc-8.3.1-2.fc29.x86_64
cmake-3.14.5-1.fc29.x86_64
```

Compilation failed with:
```
/usr/bin/cmake -E cmake_link_script CMakeFiles/flame.dir/link.txt --verbose=1
[100%] Linking CXX executable tests
/usr/bin/cmake -E cmake_link_script CMakeFiles/tests.dir/link.txt --verbose=1
/usr/lib64/ccache/c++  -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -g  -Wl,-z,relro   -Wl,-z,now -specs=/usr/lib/rpm/redhat/redhat-hardened-ld CMakeFiles/flame.dir/3rd/docopt.cpp/docopt.cpp.o CMakeFiles/flame.dir/flame/main.cpp.o  -o flame libflamecore.so 
/usr/lib64/ccache/c++  -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -g  -Wl,-z,relro   -Wl,-z,now -specs=/usr/lib/rpm/redhat/redhat-hardened-ld CMakeFiles/tests.dir/tests/main.cpp.o  -o tests libflamecore.so 
/usr/bin/ld: CMakeFiles/flame.dir/flame/main.cpp.o: undefined reference to symbol 'uv_unref'
/usr/bin/ld: //usr/lib64/libuv.so.1: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
make[2]: *** [CMakeFiles/flame.dir/build.make:103: flame] Error 1
```

Alternative working fix was adding PUBLIC ${LIBUV_LIBRARIES} to flamecore target.