### PR TITLE
Provide install target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,3 +109,8 @@ target_include_directories(tests
 target_link_libraries(tests
         PRIVATE flamecore
         )
+
+install(TARGETS flame flamecore
+        RUNTIME DESTINATION bin
+        LIBRARY DESTINATION lib${LIB_SUFFIX}
+        ARCHIVE DESTINATION lib/static)


### PR DESCRIPTION
CMake provides easy way for installing built binaries.
Add make install target with DESTDIR support. Support lib64
install suffix.

Signed-off-by: Petr Menšík <pemensik@redhat.com>