### PR TITLE
Metrics fixes and improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ if (NOT CMAKE_BUILD_TYPE)
 endif()
 # ::-------------------------------------------------------------------------::
 
-project(flamethrower VERSION 0.10.1)
+project(flamethrower VERSION 0.10.2)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 

--- a/flame/metrics.cpp
+++ b/flame/metrics.cpp
@@ -295,7 +295,7 @@ void MetricsMgr::aggregate_trafgen(const Metrics *m)
 
     if (_agg_total_response_max_ms == 0) {
         _agg_total_response_max_ms = m->_period_response_max_ms;
-    } else if (m->_period_response_max_ms && m->_period_response_max_ms > _agg_period_response_max_ms) {
+    } else if (m->_period_response_max_ms && m->_period_response_max_ms > _agg_total_response_max_ms) {
         _agg_total_response_max_ms = m->_period_response_max_ms;
     }
 

--- a/flame/metrics.cpp
+++ b/flame/metrics.cpp
@@ -16,7 +16,7 @@ extern ldns_lookup_table ldns_rcodes[];
 
 std::shared_ptr<Metrics> MetricsMgr::create_trafgen_metrics()
 {
-    auto m = std::make_shared<Metrics>(_loop, *this);
+    auto m = std::make_shared<Metrics>(_loop);
     _metrics.push_back(m);
     return m;
 }
@@ -80,6 +80,7 @@ void MetricsMgr::flush_to_disk()
 {
     update_runtime();
     json j;
+    j["period_number"] = _aggregate_count;
     j["total_s_count"] = _agg_total_s_count;
     j["total_r_count"] = _agg_total_r_count;
     j["period_timeouts"] = _agg_period_timeouts;
@@ -244,6 +245,7 @@ void MetricsMgr::aggregate_trafgen(const Metrics *m)
     if (_per_trafgen_metrics && _metric_file.is_open()) {
         // record per trafgen metrics to out file
         json j;
+        j["period_number"] = _aggregate_count;
         j["period_s_count"] = m->_period_s_count;
         j["period_r_count"] = m->_period_r_count;
         j["run_id"] = _run_id;

--- a/flame/metrics.h
+++ b/flame/metrics.h
@@ -118,7 +118,6 @@ class Metrics
     friend class MetricsMgr;
 
     std::shared_ptr<uvw::Loop> _loop;
-    MetricsMgr &_mgr;
 
     std::string _trafgen_id;
 
@@ -147,9 +146,8 @@ public:
     constexpr static const double HR_TO_SEC_MULT = 0.000000001;
     constexpr static const double HR_TO_MSEC_MULT = 0.000001;
 
-    Metrics(std::shared_ptr<uvw::Loop> l, MetricsMgr &m)
+    Metrics(std::shared_ptr<uvw::Loop> l)
         : _loop(l)
-        , _mgr(m)
     {
     }
 

--- a/flame/version.h
+++ b/flame/version.h
@@ -1,2 +1,2 @@
-#define FLAME_VERSION_NUM "0.10.1"
-#define FLAME_VERSION "Flamethrower 0.10.1"
+#define FLAME_VERSION_NUM "0.10.2"
+#define FLAME_VERSION "Flamethrower 0.10.2"


### PR DESCRIPTION
- fix bug in calculation of max `total_response_max_ms`
- remove unused `MetricsMgr` reference to fix compile warning
- add `period_number` to json output
