### PR TITLE
Change "tcptls" to "dot"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ add_compile_options(-Wall)
 find_package(PkgConfig)
 
 pkg_search_module(LIBLDNS REQUIRED libldns ldns)
-pkg_check_modules(LIBUV REQUIRED libuv)
+pkg_check_modules(LIBUV REQUIRED libuv>=1.23)
 pkg_check_modules(LIBGNUTLS REQUIRED gnutls>=3.3)
 
 # ::-------------------------------------------------------------------------:: 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This code is released under Apache License 2.0. You can find terms and condition
 Overview
 --------
 
-Flamethrower is a small, fast, configurable tool for functional testing, benchmarking, and stress testing DNS servers and networks. It supports IPv4, IPv6, UDP and TCP, and has a modular system for generating queries used in the tests.
+Flamethrower is a small, fast, configurable tool for functional testing, benchmarking, and stress testing DNS servers and networks. It supports IPv4, IPv6, UDP, TCP, and DoT and has a modular system for generating queries used in the tests.
 
 Originally built as an alternative to dnsperf (https://github.com/DNS-OARC/dnsperf), many of the command line options are compatible.
 
@@ -69,7 +69,7 @@ Flame target, port 5300, TCP:
 flame -p 5300 -P tcp target.test.com
 ```
 
-Flame target, port 443, DoT (tcptls):
+Flame target, port 443, DoT:
 ```
 flame -p 443 -P dot target.test.com
 ```

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Flamethrower [![Build Status](https://travis-ci.org/DNS-OARC/flamethrower.svg?br
 
 A DNS performance and functional testing utility.
 
-2017-2019 © NSONE, Inc.
+2017-2020© NSONE, Inc.
 
 License
 -------
@@ -16,7 +16,7 @@ Overview
 
 Flamethrower is a small, fast, configurable tool for functional testing, benchmarking, and stress testing DNS servers and networks. It supports IPv4, IPv6, UDP and TCP, and has a modular system for generating queries used in the tests.
 
-It was built as an alternative to dnsperf (https://nominum.com/measurement-tools/), and many of the command line options are compatible.
+Originally built as an alternative to dnsperf (https://github.com/DNS-OARC/dnsperf), many of the command line options are compatible.
 
 Dependencies
 ------------
@@ -69,9 +69,9 @@ Flame target, port 5300, TCP:
 flame -p 5300 -P tcp target.test.com
 ```
 
-Flame target, port 443, TCPTLS:
+Flame target, port 443, DoT (tcptls):
 ```
-flame -p 443 -P tcptls target.test.com
+flame -p 443 -P dot target.test.com
 ```
 
 Flame target with random labels:

--- a/flame/main.cpp
+++ b/flame/main.cpp
@@ -194,6 +194,7 @@ int main(int argc, char *argv[])
     long c_count = args["-c"].asLong();
 
     Protocol proto{Protocol::UDP};
+    // note: tcptls is available as a deprecated alternative to dot
     if (args["-P"].asString() == "tcp" || args["-P"].asString() == "dot" || args["-P"].asString() == "tcptls") {
         if (args["-P"].asString() == "dot" || args["-P"].asString() == "tcptls") {
             proto = Protocol::DOT;

--- a/flame/main.cpp
+++ b/flame/main.cpp
@@ -51,9 +51,9 @@ static const char USAGE[] =
       -r RECORD        The base record to use as the DNS query for generators [default: test.com]
       -T QTYPE         The query type to use for generators [default: A]
       -f FILE          Read records from FILE, one per row, QNAME TYPE
-      -p PORT          Which port to flame [defaults: 53, 853 for tcptls]
+      -p PORT          Which port to flame [defaults: 53, 853 for DoT]
       -F FAMILY        Internet family (inet/inet6) [default: inet]
-      -P PROTOCOL      Protocol to use (udp/tcp/tcptls) [default: udp]
+      -P PROTOCOL      Protocol to use (udp/tcp/dot) [default: udp]
       -g GENERATOR     Generate queries with the given generator [default: static]
       -o FILE          Metrics output file, JSON format
       -v VERBOSITY     How verbose output should be, 0 is silent [default: 1]
@@ -193,8 +193,13 @@ int main(int argc, char *argv[])
     long c_count = args["-c"].asLong();
 
     Protocol proto{Protocol::UDP};
-    if (args["-P"].asString() == "tcp" || args["-P"].asString() == "tcptls") {
-        proto = (args["-P"].asString() == "tcptls") ? Protocol::TCPTLS : Protocol::TCP;
+    if (args["-P"].asString() == "tcp" || args["-P"].asString() == "dot" || args["-P"].asString() == "tcptls") {
+        if (args["-P"].asString() == "dot" || args["-P"].asString() == "tcptls") {
+            proto = Protocol::DOT;
+        }
+        else if (args["-P"].asString() == "tcp") {
+            proto = Protocol::TCP;
+        }
         if (!arg_exists("-d", argc, argv))
             s_delay = 1000;
         if (!arg_exists("-q", argc, argv))
@@ -204,12 +209,12 @@ int main(int argc, char *argv[])
     } else if (args["-P"].asString() == "udp") {
         proto = Protocol::UDP;
     } else {
-        std::cerr << "protocol must be 'udp', 'tcp' or 'tcptls'" << std::endl;
+        std::cerr << "protocol must be 'udp', 'tcp' or 'dot'" << std::endl;
         return 1;
     }
 
     if (!args["-p"]) {
-        if (proto == Protocol::TCPTLS)
+        if (proto == Protocol::DOT)
             args["-p"] = std::string("853");
         else
             args["-p"] = std::string("53");

--- a/flame/trafgen.cpp
+++ b/flame/trafgen.cpp
@@ -143,7 +143,7 @@ void TrafGen::start_tcp_session()
     };
 
     // For now, treat a TLS handshake failure as malformed data
-    _tcp_session = (_traf_config->protocol == Protocol::TCPTLS)
+    _tcp_session = (_traf_config->protocol == Protocol::DOT)
         ? std::make_shared<TCPTLSSession>(_tcp_handle, malformed_data, got_dns_message, connection_ready, malformed_data)
         : std::make_shared<TCPSession>(_tcp_handle, malformed_data, got_dns_message, connection_ready);
 
@@ -292,7 +292,7 @@ void TrafGen::start()
         _sender_timer->on<uvw::TimerEvent>([this](const uvw::TimerEvent &event, uvw::TimerHandle &h) {
             if (_traf_config->protocol == Protocol::UDP) {
                 udp_send();
-            } else if (_traf_config->protocol == Protocol::TCP || _traf_config->protocol == Protocol::TCPTLS) {
+            } else if (_traf_config->protocol == Protocol::TCP || _traf_config->protocol == Protocol::DOT) {
                 start_tcp_session();
             }
         });

--- a/flame/trafgen.h
+++ b/flame/trafgen.h
@@ -17,7 +17,7 @@
 enum class Protocol {
     UDP,
     TCP,
-    TCPTLS,
+    DOT,
 };
 
 struct TrafGenConfig {

--- a/flame/version.h
+++ b/flame/version.h
@@ -1,2 +1,2 @@
-#define FLAME_VERSION_NUM "0.10.2"
-#define FLAME_VERSION "Flamethrower 0.10.2"
+#define FLAME_VERSION_NUM "0.11.0"
+#define FLAME_VERSION "Flamethrower 0.11.0"

--- a/man/flame.1.md
+++ b/man/flame.1.md
@@ -16,13 +16,12 @@ flame \--version
 
 # DESCRIPTION
 
-Flamethrower is a small, fast, configurable tool for functional testing,
-benchmarking, and stress testing DNS servers and networks. It supports IPv4,
-IPv6, UDP and TCP, and has a modular system for generating queries used in the
-tests.
+Flamethrower is a small, fast, configurable tool for functional testing, benchmarking, 
+and stress testing DNS servers and networks. It supports IPv4, IPv6, UDP, TCP, and DoT and 
+has a modular system for generating queries used in the tests.
 
-It was built as an alternative to [dnsperf](https://github.com/DNS-OARC/dnsperf)
-and many of the command line options are compatible.
+Originally built as an alternative to dnsperf (https://github.com/DNS-OARC/dnsperf), 
+many of the command line options are compatible.
 
 ## Target
 
@@ -72,7 +71,7 @@ Target can be either an IP address or host name which will be resolved first.
 -R
 : Randomize the query list before sending. Default is false.
 
--P ( udp | tcp )
+-P ( udp | tcp | dot )
 : Protocol to use. Default is udp.
 
 -Q *QPS*


### PR DESCRIPTION
Change `tcptls` to `dot` (but still accept `tcptls` on commandline for backwards compatibility). Require min libuv (fixes #29). Bump version.
