### PR TITLE
add client-subnet support to the file generator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,8 @@ add_compile_options(-Wall)
 
 find_package(PkgConfig)
 
+include(sanitizer)
+
 pkg_search_module(LIBLDNS REQUIRED libldns ldns)
 pkg_check_modules(LIBUV REQUIRED libuv)
 pkg_check_modules(LIBGNUTLS REQUIRED gnutls>=3.3)

--- a/cmake/sanitizer.cmake
+++ b/cmake/sanitizer.cmake
@@ -1,0 +1,15 @@
+# vim: set ts=4 sw=4 expandtab:
+
+option(ASAN "Build with ASAN." OFF)
+SET(SANITIZE "" CACHE STRING "Compile with sanitizer.")
+
+if (ASAN)
+    SET(SANITIZE "address")
+endif()
+
+if (SANITIZE)
+    message(STATUS "Enabled sanitizer level ${SANITIZE}")
+    add_compile_options(-fsanitize=${SANITIZE})
+    link_libraries(-fsanitize=${SANITIZE})
+endif()
+

--- a/flame/query.cpp
+++ b/flame/query.cpp
@@ -4,6 +4,7 @@
 #include "utils.h"
 #include <algorithm>
 #include <cctype>
+#include <climits>
 #include <fstream>
 #include <iomanip>
 #include <iostream>

--- a/flame/query.cpp
+++ b/flame/query.cpp
@@ -17,6 +17,7 @@
 #include <ldns/host2wire.h>
 #include <ldns/wire2host.h>
 
+#include <arpa/inet.h>
 #include <netinet/in.h>
 
 // EDNS buffer size to avoid fragmentation on IPv6
@@ -229,7 +230,7 @@ static ldns_pkt *new_query(const char *name, size_t name_len, bool name_bin,
 }
 
 void QueryGenerator::new_rec(uint8_t **dest, size_t *dest_len, const char *qname, size_t len,
-    const std::string &qtype, bool binary, uint16_t id)
+    const std::string &qtype, const std::string &prefix, bool binary, uint16_t id)
 {
 
     ldns_enum_rr_class qclass;
@@ -265,6 +266,35 @@ void QueryGenerator::new_rec(uint8_t **dest, size_t *dest_len, const char *qname
     ldns_pkt_set_edns_udp_size(query, EDNS_BUFFER_SIZE);
     ldns_pkt_set_edns_do(query, _dnssec);
 
+    if (!prefix.empty()) {
+        // todo: move string parsing to file gen; validate mask <32
+        auto slashpos = prefix.find('/');
+        auto cidr = prefix.substr(0, slashpos); // todo: copies...
+        uint8_t mask = std::stoi(prefix.substr(slashpos+1, prefix.size()));
+
+        struct sockaddr_in sa;
+        inet_pton(AF_INET, cidr.c_str(), &(sa.sin_addr)); // todo: ipv6
+        int numbytes = (mask + (CHAR_BIT - 1)) / CHAR_BIT;
+        uint16_t optionlen = 4 + numbytes;
+
+        // https://tools.ietf.org/html/rfc7871; todo: struct
+        int idx = 0;
+        int buflen = optionlen + 4; // add 2 bytes each for option code/optionlen fields
+        uint8_t *buf = (uint8_t *)malloc(buflen); // todo: check malloc
+        buf[idx++] = 0x00; // option-code msb
+        buf[idx++] = 0x08; // option-code lsb
+        buf[idx++] = optionlen >> 16; //option-len msb
+        buf[idx++] = optionlen & 0xFF; // option-len lsb
+        buf[idx++] = 0x00; // family msb
+        buf[idx++] = 0x01; // family lsb
+        buf[idx++] = mask; // source preflen
+        buf[idx++] = 0x00; // scope preflen
+        std::memcpy(&buf[idx], &sa.sin_addr.s_addr, numbytes); // address
+
+        ldns_rdf *edns_data = ldns_rdf_new(LDNS_RDF_TYPE_UNKNOWN, buflen, buf);
+        ldns_pkt_set_edns_data(query, edns_data);
+    }
+
     ldns_pkt2wire(dest, query, dest_len);
     ldns_pkt_free(query);
 }
@@ -273,7 +303,14 @@ void QueryGenerator::push_rec(const char *qname, size_t len, const std::string &
 {
 
     WireTpt w;
-    new_rec(&w.first, &w.second, qname, len, qtype, binary);
+    new_rec(&w.first, &w.second, qname, len, qtype, "", binary);
+    _wire_buffers.push_back(w);
+}
+
+void QueryGenerator::push_rec(const std::string &qname, const std::string &qtype, const std::string &prefix, bool binary)
+{
+    WireTpt w;
+    new_rec(&w.first, &w.second, qname.c_str(), qname.length(), qtype, prefix, binary);
     _wire_buffers.push_back(w);
 }
 
@@ -293,7 +330,7 @@ FileQueryGenerator::FileQueryGenerator(std::shared_ptr<Config> c,
 {
     std::ifstream file;
     std::string line;
-    std::regex splitter("^[[:space:]]*([^[:space:]]+)[[:space:]]+([^[:space:]]+)[[:space:]]*$");
+    std::regex splitter("^[[:space:]]*([^[:space:]]+)[[:space:]]+([^[:space:]]+)[[:space:]]*([^[:space:]]+)?[[:space:]]*$");
 
     file.open(fname);
     if (!file.is_open()) {
@@ -306,6 +343,9 @@ FileQueryGenerator::FileQueryGenerator(std::shared_ptr<Config> c,
         std::regex_match(line, result, splitter);
         if (result.size() == 3) {
             push_rec(std::move(result[1].str()), result[2].str(), false);
+        } else if (result.size() == 4) {
+            // todo: rewrite push_rec for less copying and do std::moves here
+            push_rec(std::move(result[1].str()), result[2].str(), result[3].str(), false);
         }
     }
 

--- a/flame/query.h
+++ b/flame/query.h
@@ -48,8 +48,9 @@ protected:
     ldns_rr_type cvt_qtype(const std::string &t);
 
     void new_rec(uint8_t **dest, size_t *dest_len, const char *qname, size_t len,
-        const std::string &qtype, bool binary, uint16_t id = 0);
+        const std::string &qtype, const std::string &prefix, bool binary, uint16_t id = 0);
     void push_rec(const char *qname, size_t len, const std::string &qtype, bool binary);
+    void push_rec(const std::string &qname, const std::string &qtype, const std::string &prefix, bool binary);
     void push_rec(const std::string &qname, const std::string &qtype, bool binary);
 
 public:


### PR DESCRIPTION
The file generator now supports ipv4/ipv6 ecs, like so:

```
[elindsey@worktop:~/code/flamethrower/build]
$ cat ../ecstest.txt 
google.com A 2001:db8:cafe:c000::/50
google.com A 192.0.100.0/24
[elindsey@worktop:~/code/flamethrower/build]
$ ./flame -v 5 -f ../ecstest.txt 216.239.36.10
```

Some pcaps:

![73399317-05ada000-42b5-11ea-90b3-4b528b74c48c](https://user-images.githubusercontent.com/47579/73762389-25721780-473e-11ea-9886-34553188adb1.png)
![73399318-05ada000-42b5-11ea-93a9-a178b76bf680](https://user-images.githubusercontent.com/47579/73762390-25721780-473e-11ea-981e-dbb785e2a3ae.png)
![73404064-cdab5a80-42be-11ea-8538-43461daab49f](https://user-images.githubusercontent.com/47579/73762392-25721780-473e-11ea-8dfa-b9e38dd8e8d1.png)

