### PR TITLE
Include definition for std::runtime_error

### DIFF
--- a/3rd/docopt.cpp/docopt.h
+++ b/3rd/docopt.cpp/docopt.h
@@ -14,6 +14,7 @@
 #include <map>
 #include <vector>
 #include <string>
+#include <stdexcept>
 
 #ifdef DOCOPT_HEADER_ONLY
     #define DOCOPT_INLINE inline

--- a/3rd/docopt.cpp/docopt_value.h
+++ b/3rd/docopt.cpp/docopt_value.h
@@ -13,6 +13,7 @@
 #include <vector>
 #include <functional> // std::hash
 #include <iosfwd>
+#include <stdexcept>
 
 namespace docopt {
 


### PR DESCRIPTION
Build fails with GCC 10.0 on [Fedora 32](https://bugzilla.redhat.com/show_bug.cgi?id=1799343). Make sure runtime_error definition is
included in headers that contain construction of std::runtime_error.