### PR TITLE
Use Debian Buster for Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:disco AS build
+FROM debian:buster-slim AS build
 
 ENV BUILD_DEPS "g++ cmake make libldns-dev libuv1-dev libgnutls28-dev pkgconf"
 
@@ -15,7 +15,7 @@ RUN \
     make all tests && \
     ./tests
 
-FROM ubuntu:disco AS runtime
+FROM debian:buster-slim AS runtime
 
 ENV RUNTIME_DEPS "libldns2 libuv1"
 


### PR DESCRIPTION
Ubuntu Disco reached end of life on 2020-01-23.

Use Debian Buster instead.