### PR TITLE
DoH: Document maximum concurrent streams for batch count

### DIFF
--- a/man/flame.1
+++ b/man/flame.1
@@ -35,6 +35,9 @@ Default is 0.0.0.0 for inet or ::0 for inet6.
 .B -q \f[I]QCOUNT\f[R]
 Number of queries to send every \f[I]DELAY_MS\f[R] interval.
 Default is 10.
+For DoH this specifies the number of concurrent HTTP/2 streams.
+If this number is larger than the maximum number of concurrent streams
+supported by the DoH server (100 for most), timeouts will happen.
 .TP
 .B -c \f[I]TCOUNT\f[R]
 Number of concurrent traffic generators per process.

--- a/man/flame.1.md
+++ b/man/flame.1.md
@@ -33,7 +33,7 @@ Target can be either an IP address or host name which will be resolved first.
 : IP address to bind to. Default is 0.0.0.0 for inet or ::0 for inet6.
 
 -q *QCOUNT*
-: Number of queries to send every *DELAY_MS* interval. Default is 10.
+: Number of queries to send every *DELAY_MS* interval. Default is 10. For DoH this specifies the number of concurrent HTTP/2 streams. If this number is larger than the maximum number of concurrent streams supported by the DoH server (100 for most), timeouts will happen.
 
 -c *TCOUNT*
 : Number of concurrent traffic generators per process. Default is 10.


### PR DESCRIPTION
This documents what happens if you set the batch count (`-q` setting) too high when using DoH. In the future, it might be better to directly report to the user when the batch count is too high (on top of only documenting it).