### PR TITLE
attempt to fix rounding in token bucket limiter

### DIFF
--- a/flame/trafgen.cpp
+++ b/flame/trafgen.cpp
@@ -119,8 +119,9 @@ void TrafGen::start_tcp_session()
                 // out of ids, have to limit
                 break;
             }
-            if (_rate_limit && !_rate_limit->consume(1, this->_loop->now()))
+            if (_rate_limit && !_rate_limit->consume(1, this->_loop->now())) {
                 break;
+            }
             id = _free_id_list.back();
             _free_id_list.pop_back();
             assert(_in_flight.find(id) == _in_flight.end());


### PR DESCRIPTION
There appears to be a problem in the token bucket limiter causing the output rate to be rounded in a way that I don't understand fully. There is a significant difference between:

```
$ ./flame -l 10 -Q 1999 x.x.x.x
```

and:

```
$ ./flame -l 10 -Q 2000 x.x.x.x
```

I'm looking for feedback as this is not an ideal solution.