### PR TITLE
adjust token precision to double to fix rate limit precision

### DIFF
--- a/flame/main.cpp
+++ b/flame/main.cpp
@@ -402,7 +402,7 @@ int main(int argc, char *argv[])
     for (auto i = 0; i < c_count; i++) {
         std::shared_ptr<TokenBucket> rl;
         if (config->rate_limit()) {
-            rl = std::make_shared<TokenBucket>(config->rate_limit() / c_count);
+            rl = std::make_shared<TokenBucket>((double)config->rate_limit() / (double)c_count);
         } else if (args["--qps-flow"]) {
             rl = std::make_shared<TokenBucket>();
             rl_list.push_back(rl);
@@ -494,7 +494,7 @@ int main(int argc, char *argv[])
             std::cout << "query list randomized" << std::endl;
         }
         if (config->rate_limit()) {
-            std::cout << "rate limit @ " << config->rate_limit() << " QPS (" << (config->rate_limit() / c_count) <<
+            std::cout << "rate limit @ " << config->rate_limit() << " QPS (" << ((double)config->rate_limit() / (double)c_count) <<
             " QPS per concurrent sender)" << std::endl;
         }
     }

--- a/flame/main.cpp
+++ b/flame/main.cpp
@@ -402,7 +402,7 @@ int main(int argc, char *argv[])
     for (auto i = 0; i < c_count; i++) {
         std::shared_ptr<TokenBucket> rl;
         if (config->rate_limit()) {
-            rl = std::make_shared<TokenBucket>((double)config->rate_limit() / (double)c_count);
+            rl = std::make_shared<TokenBucket>(config->rate_limit() / static_cast<double>(c_count));
         } else if (args["--qps-flow"]) {
             rl = std::make_shared<TokenBucket>();
             rl_list.push_back(rl);
@@ -494,7 +494,7 @@ int main(int argc, char *argv[])
             std::cout << "query list randomized" << std::endl;
         }
         if (config->rate_limit()) {
-            std::cout << "rate limit @ " << config->rate_limit() << " QPS (" << ((double)config->rate_limit() / (double)c_count) <<
+            std::cout << "rate limit @ " << config->rate_limit() << " QPS (" << config->rate_limit() / static_cast<double>(c_count) <<
             " QPS per concurrent sender)" << std::endl;
         }
     }

--- a/flame/tokenbucket.h
+++ b/flame/tokenbucket.h
@@ -14,7 +14,7 @@ public:
     {
     }
 
-    TokenBucket(const double rate)
+    TokenBucket(double rate)
         : _rate_qps(rate)
         , _token_wallet(0)
         , _last_fill_ms(0)
@@ -28,7 +28,7 @@ public:
                 _last_fill_ms = now_ms;
             } else if (now_ms > _last_fill_ms) {
                 auto elapsed_ms = (now_ms - _last_fill_ms).count();
-                double add = _rate_qps * ((double)elapsed_ms / 1000.0);
+                double add = _rate_qps * elapsed_ms / 1000.0;
                 if (_token_wallet + add >= tokens) {
                     _token_wallet += add;
                     _last_fill_ms = now_ms;

--- a/flame/tokenbucket.h
+++ b/flame/tokenbucket.h
@@ -14,7 +14,7 @@ public:
     {
     }
 
-    TokenBucket(const uint64_t rate)
+    TokenBucket(const double rate)
         : _rate_qps(rate)
         , _token_wallet(0)
         , _last_fill_ms(0)
@@ -28,7 +28,7 @@ public:
                 _last_fill_ms = now_ms;
             } else if (now_ms > _last_fill_ms) {
                 auto elapsed_ms = (now_ms - _last_fill_ms).count();
-                double add = (double)_rate_qps * ((double)elapsed_ms / 1000.0);
+                double add = _rate_qps * ((double)elapsed_ms / 1000.0);
                 if (_token_wallet + add >= tokens) {
                     _token_wallet += add;
                     _last_fill_ms = now_ms;
@@ -43,8 +43,8 @@ public:
     }
 
 private:
-    uint64_t _rate_qps;
-    uint64_t _token_wallet;
+    double _rate_qps;
+    double _token_wallet;
     // milliseconds, based on uv_now() http://docs.libuv.org/en/v1.x/loop.html#c.uv_now
     uvw::Loop::Time _last_fill_ms;
 };


### PR DESCRIPTION
Address same issue as #51 

```
√ cmake-build-debug % ./flame -Q 15000 localhost                                                                                                                                                         (rate-limit-precision)flamethrower
binding to 0.0.0.0
flaming target(s) [127.0.0.1] on port 53 with 10 concurrent generators, each sending 10 queries every 1ms on protocol udp
query generator [static] contains 1 record(s)
rate limit @ 15000 QPS (1500 QPS per concurrent sender)
0.931194s: send: 13950, avg send: 13950, recv: 0, avg recv: 0, min/avg/max resp: 0/nan/0ms, in flight: 13940, timeouts: 0
1.93186s: send: 15000, avg send: 14475, recv: 0, avg recv: 0, min/avg/max resp: 0/nan/0ms, in flight: 28940, timeouts: 0
2.93364s: send: 15000, avg send: 14650, recv: 0, avg recv: 0, min/avg/max resp: 0/nan/0ms, in flight: 43940, timeouts: 0
3.93967s: send: 15000, avg send: 14737, recv: 0, avg recv: 0, min/avg/max resp: 0/nan/0ms, in flight: 44933, timeouts: 14017
```
```
√ cmake-build-debug % ./flame -Q 14990 localhost                                                                                                                                                         (rate-limit-precision)flamethrower
binding to 0.0.0.0
flaming target(s) [127.0.0.1] on port 53 with 10 concurrent generators, each sending 10 queries every 1ms on protocol udp
query generator [static] contains 1 record(s)
rate limit @ 14990 QPS (1499 QPS per concurrent sender)
0.933284s: send: 13970, avg send: 13970, recv: 0, avg recv: 0, min/avg/max resp: 0/nan/0ms, in flight: 13960, timeouts: 0
1.93354s: send: 14990, avg send: 14480, recv: 0, avg recv: 0, min/avg/max resp: 0/nan/0ms, in flight: 28950, timeouts: 0
2.93537s: send: 15000, avg send: 14653, recv: 0, avg recv: 0, min/avg/max resp: 0/nan/0ms, in flight: 43950, timeouts: 0
3.94214s: send: 15090, avg send: 14762, recv: 0, avg recv: 0, min/avg/max resp: 0/nan/0ms, in flight: 45005, timeouts: 14035
4.94448s: send: 14990, avg send: 14807, recv: 0, avg recv: 0, min/avg/max resp: 0/nan/0ms, in flight: 44998, timeouts: 14997
```
```
√ cmake-build-debug % ./flame -Q 99 localhost                                                                                                                                                            (rate-limit-precision)flamethrower
binding to 0.0.0.0
flaming target(s) [127.0.0.1] on port 53 with 10 concurrent generators, each sending 10 queries every 1ms on protocol udp
query generator [static] contains 1 record(s)
rate limit @ 99 QPS (9.9 QPS per concurrent sender)
0.932383s: send: 90, avg send: 90, recv: 0, avg recv: 0, min/avg/max resp: 0/nan/0ms, in flight: 80, timeouts: 0
1.93275s: send: 100, avg send: 95, recv: 0, avg recv: 0, min/avg/max resp: 0/nan/0ms, in flight: 180, timeouts: 0
2.93315s: send: 100, avg send: 96, recv: 0, avg recv: 0, min/avg/max resp: 0/nan/0ms, in flight: 280, timeouts: 0
```