### PR TITLE
Handle Binding Errors

### DIFF
--- a/flame/metrics.cpp
+++ b/flame/metrics.cpp
@@ -268,7 +268,11 @@ void MetricsMgr::aggregate_trafgen(const Metrics *m)
     _agg_total_timeouts += m->_period_timeouts;
 
     _agg_period_bad_count += m->_period_bad_count;
+    _agg_total_bad_count += m->_period_bad_count;
+
     _agg_period_net_errors += m->_period_net_errors;
+    _agg_total_net_errors += m->_period_net_errors;
+
     _agg_period_tcp_connections += m->_period_tcp_connections;
     _agg_total_tcp_connections += m->_period_tcp_connections;
 

--- a/flame/trafgen.h
+++ b/flame/trafgen.h
@@ -86,6 +86,7 @@ class TrafGen
     void start_udp();
     void udp_send();
 
+    void connect_tcp_events();
     void start_tcp_session();
     void start_wait_timer_for_tcp_finish();
 


### PR DESCRIPTION
I used this tool to run a test where I generated enough TCP connects to put all local ephemeral TCP ports into the TIME_WAIT state. The tool continued running, but all generators stopped sending queries, reporting "sent: 0" queries on periodic updates.

This change allows flamethrower to recover if ephemeral ports become available, and also reports out what error has occurred. 