### PR TITLE
Make the tcp-based modes honor the -d option.

### DIFF
--- a/flame/trafgen.cpp
+++ b/flame/trafgen.cpp
@@ -271,7 +271,7 @@ void TrafGen::start_wait_timer_for_tcp_finish()
         _finish_session_timer->close();
         _tcp_handle->close();
     });
-    _finish_session_timer->start(uvw::TimerHandle::Time{1}, uvw::TimerHandle::Time{50});
+    _finish_session_timer->start(uvw::TimerHandle::Time{1}, uvw::TimerHandle::Time{_traf_config->s_delay});
 }
 
 void TrafGen::udp_send()


### PR DESCRIPTION
Previously, the value was ignored and set to 50ms.