### PR TITLE
DoH: increase temp. receive buffer size to 16K (#1)

### DIFF
--- a/flame/httpssession.cpp
+++ b/flame/httpssession.cpp
@@ -295,7 +295,7 @@ void HTTPSSession::receive_data(const char data[], size_t _len)
         do_handshake();
         break;
     case LinkState::DATA:
-        char buf[2048];
+        char buf[16384];
         for (;;) {
             ssize_t len = gnutls_record_recv(_gnutls_session, buf, sizeof(buf));
             if (len > 0) {


### PR DESCRIPTION
This MR increases the size of a temporary receive buffer to hold
16K - exactly one max sized TLS record. This small change ensures
flamethrower compatibility with servers employing write request
buffering (consolidation) and deployments where TLS encryption is
offloaded to third-party software (e.g. haproxy). In the latter case,
the software could employ its own write buffering technics.

I managed to hit both of these use cases. In such a case, one would see
a lot of "malformed data" messages from the flamethrower.