### PR TITLE
3rd shared libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,12 +52,16 @@ pkg_check_modules(LIBUV REQUIRED libuv>=1.23)
 pkg_check_modules(LIBGNUTLS REQUIRED gnutls>=3.3)
 
 option(DOH_ENABLE "Enable DNS over HTTPS (DoH) support" OFF)
+option(USE_HTTP_PARSER "Use http_parse library instead of url_parse" OFF)
 if (DOH_ENABLE)
     pkg_search_module(LIBNGHTTP2 REQUIRED nghttp2 libnghttp2)
     message(STATUS "DNS over HTTPS (DoH) support is enabled")
     add_definitions(-DDOH_ENABLE)
 else ()
     message(STATUS "DNS over HTTPS (DoH) support is disabled")
+endif()
+if (USE_HTTP_PARSER)
+    add_definitions(-DUSE_HTTP_PARSER)
 endif()
 
 pkg_search_module(CATCH QUIET catch2>=2.3 catch>=2.3)
@@ -72,6 +76,20 @@ if (NOT LIBDOCOPT_FOUND)
     set(LIBDOCOPT_LIBRARIES docopt)
     add_library(docopt STATIC 3rd/docopt.cpp/docopt.cpp)
     target_include_directories(docopt PUBLIC ${LIBDOCOPT_INCLUDE_DIRS})
+endif()
+
+if (NOT USE_HTTP_PARSER)
+    set(LIBURL_PARSER_INCLUDE_DIRS "${CMAKE_SOURCE_DIR}/3rd/url-parser")
+    set(LIBURL_PARSER_LIBRARIES url_parser)
+    add_library(url_parser STATIC 3rd/url-parser/url_parser.c)
+    target_include_directories(url_parser PUBLIC ${LIBURL_PARSER_INCLUDE_DIRS})
+else()
+    find_file(HTTP_PARSER_H NAMES http_parser.h)
+    find_library(HTTP_PARSER_LIBRARY NAMES http_parser)
+    if (NOT HTTP_PARSER_H OR NOT HTTP_PARSER_LIBRARY)
+        status(FATAL "http_parser library development files not found")
+    endif()
+    set(LIBURL_PARSER_LIBRARIES ${HTTP_PARSER_LIBRARY})
 endif()
 
 set(flamecore_src
@@ -95,7 +113,7 @@ set(flamecore_dirs
     PUBLIC ${LIBLDNS_INCLUDE_DIRS}
     PUBLIC ${LIBGNUTLS_INCLUDE_DIRS}
     PUBLIC "${CMAKE_SOURCE_DIR}/3rd/json"
-    PUBLIC "${CMAKE_SOURCE_DIR}/3rd/url-parser"
+    PUBLIC ${LIBURL_PARSER_INCLUDE_DIRS}
     PUBLIC "${CMAKE_SOURCE_DIR}/3rd/uvw"
     PUBLIC "${CMAKE_SOURCE_DIR}/3rd/cpp-httplib"
     )
@@ -110,7 +128,6 @@ set(flamecore_libs
     )
 
 set(flame_execs
-    3rd/url-parser/url_parser.c
     flame/main.cpp
     )
 
@@ -160,6 +177,7 @@ target_link_libraries(flame
         PRIVATE ${LIBUV_LIBRARIES}
         PRIVATE ${LIBDOCOPT_LDFLAGS}
         PRIVATE ${LIBDOCOPT_LIBRARIES}
+        PRIVATE ${LIBURL_PARSER_LIBRARIES}
         PRIVATE Threads::Threads
         )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,10 +61,18 @@ else ()
 endif()
 
 pkg_search_module(CATCH QUIET catch2>=2.3 catch>=2.3)
+pkg_check_modules(LIBDOCOPT docopt)
 
 # ::-------------------------------------------------------------------------:: 
 # BUILD TARGETS
 # ::-------------------------------------------------------------------------:: 
+
+if (NOT LIBDOCOPT_FOUND)
+    set(LIBDOCOPT_INCLUDE_DIRS "${CMAKE_SOURCE_DIR}/3rd/docopt.cpp")
+    set(LIBDOCOPT_LIBRARIES docopt)
+    add_library(docopt STATIC 3rd/docopt.cpp/docopt.cpp)
+    target_include_directories(docopt PUBLIC ${LIBDOCOPT_INCLUDE_DIRS})
+endif()
 
 set(flamecore_src
     flame/metrics.cpp
@@ -86,7 +94,6 @@ set(flamecore_dirs
     PUBLIC ${LIBUV_INCLUDE_DIRS}
     PUBLIC ${LIBLDNS_INCLUDE_DIRS}
     PUBLIC ${LIBGNUTLS_INCLUDE_DIRS}
-    PUBLIC "${CMAKE_SOURCE_DIR}/3rd/docopt.cpp"
     PUBLIC "${CMAKE_SOURCE_DIR}/3rd/json"
     PUBLIC "${CMAKE_SOURCE_DIR}/3rd/url-parser"
     PUBLIC "${CMAKE_SOURCE_DIR}/3rd/uvw"
@@ -103,9 +110,12 @@ set(flamecore_libs
     )
 
 set(flame_execs
-    3rd/docopt.cpp/docopt.cpp
     3rd/url-parser/url_parser.c
     flame/main.cpp
+    )
+
+set(flame_dirs
+    PUBLIC ${LIBDOCOPT_INCLUDE_DIRS}
     )
 
 if (DOH_ENABLE)
@@ -142,10 +152,14 @@ target_link_libraries(flamecore ${flamecore_libs})
 
 add_executable(flame ${flame_execs})
 
+target_include_directories(flame ${flame_dirs})
+
 target_link_libraries(flame
         PRIVATE flamecore
         PRIVATE ${LIBUV_LDFLAGS}
         PRIVATE ${LIBUV_LIBRARIES}
+        PRIVATE ${LIBDOCOPT_LDFLAGS}
+        PRIVATE ${LIBDOCOPT_LIBRARIES}
         PRIVATE Threads::Threads
         )
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,10 @@ Build Dependencies
 Optional DoH support requires:
 * nghttp2
 
+Optional dependencies:
+* catch >= 2.3
+* docopt
+
 Building
 --------
 

--- a/flame/httpssession.h
+++ b/flame/httpssession.h
@@ -2,10 +2,15 @@
 
 #include <gnutls/gnutls.h>
 #include <nghttp2/nghttp2.h>
-#include <url_parser.h>
 
 #ifdef DOH_ENABLE
 #include "base64.h"
+#endif
+
+#ifdef USE_HTTP_PARSER
+#include <http_parser.h>
+#else
+#include <url_parser.h>
 #endif
 
 #include "http.h"

--- a/flame/main.cpp
+++ b/flame/main.cpp
@@ -22,6 +22,12 @@
 
 #include "version.h"
 
+#ifdef USE_HTTP_PARSER
+#include <http_parser.h>
+#else
+#include <url_parser.h>
+#endif
+
 static const char METRIC_ROUTE[] = "/api/v1/metrics";
 static const char USAGE[] =
     R"(Flamethrower.

--- a/flame/target.h
+++ b/flame/target.h
@@ -1,7 +1,7 @@
 #ifndef FLAMETHROWER_TARGET_H
 #define FLAMETHROWER_TARGET_H
 
-#include <url_parser.h>
+struct http_parser_url;
 
 struct Target {
     http_parser_url* parsed;


### PR DESCRIPTION
Make docopt.cpp detect system package and use it if available. Use bundled library if not present.

Because url_parser seems to be just stripped http_parser, allow linking against that library. It seems to be far better maintained and is already packaged for Fedora distribution. Require manual override because it is (somehow) different library to use it.