### PR TITLE
Fix issues when running with a low delay (-d option)

### DIFF
--- a/flame/httpssession.h
+++ b/flame/httpssession.h
@@ -78,6 +78,7 @@ public:
 
     void settings_received();
 
+    std::unordered_map<int32_t, std::vector<uint8_t>> _recv_chunks;
 protected:
     void destroy_stream();
     void destroy_session();

--- a/flame/trafgen.h
+++ b/flame/trafgen.h
@@ -77,6 +77,7 @@ class TrafGen
     // a randomized list of query ids that are not currently in flight
     std::vector<uint16_t> _free_id_list;
 
+    bool _started_sending;
     bool _stopping;
 
     void handle_timeouts(bool force_reset = false);


### PR DESCRIPTION
When running DoT or DoH with a low delay on a fast network, a race conditon appears that results in flamethrower livelocking.

The second commit fix a doh issue found while testing the first commit.