### PR TITLE
Add support to build on MacOS with M1 cpus.

### DIFF
--- a/3rd/catch/catch2/catch.hpp
+++ b/3rd/catch/catch2/catch.hpp
@@ -4818,9 +4818,15 @@ namespace Catch {
 }
 
 #ifdef CATCH_PLATFORM_MAC
+#if defined(__GNUC__) && (defined(__i386) || defined(__x86_64))
+#define CATCH_TRAP() __asm__("int $3\n" \
+                             :          \
+                             :) /* NOLINT */
+#else                           // Fall back to the generic way.
+#include <signal.h>
 
-    #define CATCH_TRAP() __asm__("int $3\n" : : ) /* NOLINT */
-
+#define CATCH_TRAP() raise(SIGTRAP)
+#endif
 #elif defined(CATCH_PLATFORM_LINUX)
     // If we can use inline assembler, do it because this allows us to break
     // directly at the location of the failing check instead of breaking inside


### PR DESCRIPTION
The existing code depended on the processor being x86_64.

Newer Macs are M1 (arm64)  based machines.

Fallback to using raise() when on a M1.