### PR TITLE
Move base64 to flamecore

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,6 +158,7 @@ if (DOH_ENABLE)
         flame/http.h
         flame/httpssession.cpp
         flame/httpssession.h
+        3rd/base64url/base64.cpp
         )
 
     set(flamecore_dirs
@@ -170,11 +171,6 @@ if (DOH_ENABLE)
         ${flamecore_libs}
         PRIVATE ${LIBNGHTTP2_LDFLAGS}
         PRIVATE ${LIBNGHTTP2_LIBRARIES}
-        )
-
-    set(flame_execs
-        ${flame_execs}
-        3rd/base64url/base64.cpp
         )
 endif()
 


### PR DESCRIPTION
It does not work on EPEL8 with gcc-8.4.1 current way, but works just
fine on Fedora's gcc-11.2.1.  flame/query.cpp uses base64_encode and
thus needs it also in flamecore already.

Without this change building of tests fails with:
``libflamecore.so: undefined reference to `base64_encode[abi:cxx11](unsigned char const*, unsigned int)'``

Sample of [failed build on EPEL8](https://kojipkgs.fedoraproject.org//work/tasks/2277/75892277/build.log).