### PR TITLE
Compile under gcc 12.0.0

### DIFF
--- a/flame/query.cpp
+++ b/flame/query.cpp
@@ -5,9 +5,11 @@
 #include <algorithm>
 #include <cctype>
 #include <climits>
+#include <cstring>
 #include <fstream>
 #include <iomanip>
 #include <iostream>
+#include <iterator>
 #include <regex>
 #include <sstream>
 #include <stdexcept>


### PR DESCRIPTION
Add missing includes to query.cpp. It does not compile anymore on gcc 12
without it.