### PR TITLE
TCP, DoT, DoH: Properly handle large responses

### DIFF
--- a/flame/httpssession.cpp
+++ b/flame/httpssession.cpp
@@ -77,9 +77,12 @@ void HTTPSSession::destroy_session()
 
 void HTTPSSession::process_receive(const uint8_t *data, size_t len)
 {
-    const size_t MIN_DNS_QUERY_SIZE = 17;
-    const size_t MAX_DNS_QUERY_SIZE = 512;
-    if (len < MIN_DNS_QUERY_SIZE || len > MAX_DNS_QUERY_SIZE) {
+    // dnsheader is 12, at least one byte for the minimum name,
+    // two bytes for the qtype and another two for the qclass
+    const size_t MIN_DNS_RESPONSE_SIZE = 17;
+    // 512 over UDP without EDNS, but 65535 over TCP
+    const size_t MAX_DNS_RESPONSE_SIZE = 65535;
+    if (len < MIN_DNS_RESPONSE_SIZE || len > MAX_DNS_RESPONSE_SIZE) {
         std::cerr << "malformed data" << std::endl;
         _malformed_data();
         return;

--- a/flame/tcpsession.cpp
+++ b/flame/tcpsession.cpp
@@ -55,8 +55,6 @@ void TCPSession::receive_data(const char data[], size_t len)
     // dnsheader is 12, at least one byte for the minimum name,
     // two bytes for the qtype and another two for the qclass
     const size_t MIN_DNS_RESPONSE_SIZE = 17;
-    // 512 over UDP without EDNS, but 65535 over TCP
-    const size_t MAX_DNS_RESPONSE_SIZE = 65535;
 
     _buffer.append(data, len);
 
@@ -70,7 +68,10 @@ void TCPSession::receive_data(const char data[], size_t len)
         size = static_cast<unsigned char>(_buffer[1]) |
                static_cast<unsigned char>(_buffer[0]) << 8;
 
-        if (size < MIN_DNS_RESPONSE_SIZE || size > MAX_DNS_RESPONSE_SIZE) {
+        // no need to check the maximum size here since the maximum size
+        // that a std::uint16t_t can hold, std::numeric_limits<std::uint16_t>::max()
+        // (65535 bytes) is allowed over TCP
+        if (size < MIN_DNS_RESPONSE_SIZE) {
             _malformed_data();
             break;
         }

--- a/flame/tcpsession.cpp
+++ b/flame/tcpsession.cpp
@@ -52,8 +52,11 @@ void TCPSession::close()
 // accumulate data and try to extract DNS messages
 void TCPSession::receive_data(const char data[], size_t len)
 {
-    const size_t MIN_DNS_QUERY_SIZE = 17;
-    const size_t MAX_DNS_QUERY_SIZE = 512;
+    // dnsheader is 12, at least one byte for the minimum name,
+    // two bytes for the qtype and another two for the qclass
+    const size_t MIN_DNS_RESPONSE_SIZE = 17;
+    // 512 over UDP without EDNS, but 65535 over TCP
+    const size_t MAX_DNS_RESPONSE_SIZE = 65535;
 
     _buffer.append(data, len);
 
@@ -67,7 +70,7 @@ void TCPSession::receive_data(const char data[], size_t len)
         size = static_cast<unsigned char>(_buffer[1]) |
                static_cast<unsigned char>(_buffer[0]) << 8;
 
-        if (size < MIN_DNS_QUERY_SIZE || size > MAX_DNS_QUERY_SIZE) {
+        if (size < MIN_DNS_RESPONSE_SIZE || size > MAX_DNS_RESPONSE_SIZE) {
             _malformed_data();
             break;
         }


### PR DESCRIPTION
Responses received over UDP are limited to 512 bytes (without EDNS) but TCP, DoT and DoH ones are only limited to 2^16-1 (65535) bytes.
Without this fix flamethrower reports large responses as timeouts, which seems completely wrong.