### PR TITLE
docs: fix README sentence fragment, add Ubuntu build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,15 @@ Start by installing build requirements. On Fedora, run:
 dnf install gcc g++ meson pkgconf ninja-build ldns-devel libuv-devel gnutls-devel libnghttp2-devel
 ```
 
+On Ubuntu 24.04 LTS, the system meson package doesn't support C23, and so installing meson via pip is the easiest path. Run:
+
+```
+apt-get install g++ ninja-build libuv1-dev libldns-dev libnghttp2-dev gnutls-dev pkgconf python3-pip python3.12-venv
+python3 -m venv .venv
+source .venv bin/activate
+pip3 install meson
+```
+
 Go to the checked-out repository and run:
 
 ```

--- a/README.md
+++ b/README.md
@@ -104,8 +104,6 @@ flame file --targets myresolvers.txt
 * gnutls
 * nghttp2 (optional for DNS-over-HTTPS support)
 
-To insta
-
 ## Building
 
 Start by installing build requirements. On Fedora, run:


### PR DESCRIPTION
:wave: Thanks for the useful tool.

I noticed there was an unfinished sentence fragment added in the README "Build Dependencies" section as part of https://github.com/DNS-OARC/flamethrower/pull/111. The first commit in this branch removes it.

I also wanted to offer some Ubuntu 24.04 LTS build instructions in case it was helpful. This was done in a separate commit in case the project isn't interested in keeping these instructions up-to-date over time, in which case I'd be happy to drop it. The process is a little bit more annoying than with Fedora because the system meson version is too old to support C23.

