### PR TITLE
(feat) Add PROXY protocol v2 (PPv2) header support

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,16 @@ Flame multiple target at once, reading the list from a file:
 flame file --targets myresolvers.txt
 ```
 
+Flame target with a PROXY protocol v2 header (e.g. testing through a proxy like dnsdist or HAProxy):
+```
+flame --proxy 192.168.1.100#4321-10.0.0.1#53 target.test.com
+```
+
+Same with IPv6 addresses (wrap in brackets):
+```
+flame -F inet6 --proxy [2001:db8::1]#4321-[2001:db8::2]#53 target.test.com
+```
+
 ## Detailed Features
 
 ### Query Generators
@@ -82,6 +92,14 @@ flame file --targets myresolvers.txt
 ### Output Metrics
 
  Flamethrower can generate detailed metrics for each of its concurrent senders. Metrics include send and receive counts, timeouts, min, max and average latency, errors, and the like. The output format is JSON, and is suitable for ingestion into databases such as Elastic for further processing or visualization. See the `-o` flag.
+
+### PROXY Protocol v2
+
+ Flamethrower can prepend a [PROXY protocol v2](https://www.haproxy.org/download/2.9/doc/proxy-protocol.txt) (PPv2) header to DNS queries. This is useful for testing DNS servers behind proxies (e.g. dnsdist, HAProxy) that use PPv2 to convey original client address information.
+
+ Use `--proxy SRC_ADDR[#SRC_PORT]-DST_ADDR[#DST_PORT]` to specify the source and destination addresses encoded in the header. For IPv6, wrap addresses in brackets: `[addr]`. Ports are optional and default to 0.
+
+ The PPv2 header is prepended per-datagram for UDP and sent once at connection establishment for TCP/DoT/DoH.
 
 ### Concurrency
 

--- a/flame/main.cpp
+++ b/flame/main.cpp
@@ -13,6 +13,7 @@
 #include "docopt.h"
 #include "http.h"
 #include "metrics.h"
+#include "proxy.h"
 #include "query.h"
 #include "trafgen.h"
 #include "utils.h"
@@ -29,7 +30,7 @@ static const char USAGE[] =
       flame [-b BIND_IP] [-q QCOUNT] [-c TCOUNT] [-p PORT] [-d DELAY_MS] [-r RECORD] [-T QTYPE]
             [-o FILE] [-l LIMIT_SECS] [-t TIMEOUT] [-F FAMILY] [-f FILE] [-n LOOP] [-P PROTOCOL] [-M HTTPMETHOD]
             [-Q QPS] [-g GENERATOR] [-v VERBOSITY] [-R] [--class CLASS] [--qps-flow SPEC]
-            [--dnssec] [--targets FILE] [--http-srv PORT]
+            [--dnssec] [--targets FILE] [--http-srv PORT] [--proxy PROXY_SPEC]
             TARGET [GENOPTS]...
       flame (-h | --help)
       flame --version
@@ -67,6 +68,7 @@ static const char USAGE[] =
       -R               Randomize the query list before sending [default: false]
       --targets FILE   Get the list of TARGETs from the given file, one line per host or IP
       --dnssec         Set DO flag in EDNS
+      --proxy PROXY_SPEC  Prepend a PROXY v2 header. Format: SRC_ADDR[#SRC_PORT]-DST_ADDR[#DST_PORT] (use [addr] for IPv6)
 
      Generators:
 
@@ -424,6 +426,18 @@ int main(int argc, char *argv[])
     traf_config->method = method;
 #endif
     traf_config->r_timeout = args["-t"].asLong();
+
+    if (args["--proxy"]) {
+        try {
+            traf_config->proxy_info = parse_proxy_spec(args["--proxy"].asString(), AF_UNSPEC);
+            if (config->verbosity()) {
+                std::cout << "PROXY v2 header enabled" << std::endl;
+            }
+        } catch (const std::runtime_error &e) {
+            std::cerr << "proxy spec error: " << e.what() << std::endl;
+            return 1;
+        }
+    }
 
     std::vector<std::shared_ptr<TrafGen>> throwers;
     for (auto i = 0; i < c_count; i++) {

--- a/flame/protocol.h
+++ b/flame/protocol.h
@@ -1,0 +1,13 @@
+// Copyright 2017 NSONE, Inc
+// Copyright 2025 Flamethrower Contributors
+
+#pragma once
+
+enum class Protocol {
+    UDP,
+    TCP,
+#ifdef DOH_ENABLE
+    DOH,
+#endif
+    DOT,
+};

--- a/flame/proxy.cpp
+++ b/flame/proxy.cpp
@@ -1,0 +1,145 @@
+// Copyright 2025 Flamethrower Contributors
+
+#include <cstring>
+#include <stdexcept>
+#include <vector>
+
+#include <arpa/inet.h>
+#include <netdb.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+
+#include "proxy.h"
+#include "utils.h"
+
+ProxyInfo parse_proxy_spec(const std::string &spec, int family)
+{
+    ProxyInfo info{};
+    info.enabled = true;
+
+    auto parts = split(spec, '-');
+    if (parts.size() != 2) {
+        throw std::runtime_error("invalid proxy spec format: expecting SRC-DST");
+    }
+
+    auto parse_addr_port = [](const std::string &s, struct sockaddr_storage &ss, int hint_family) -> int {
+        auto ap_parts = split(s, '#');
+        std::string host;
+        std::string port_str = "0";
+
+        if (!ap_parts[0].empty() && ap_parts[0].front() == '[' && ap_parts[0].back() == ']') {
+            host = ap_parts[0].substr(1, ap_parts[0].length() - 2);
+        } else {
+            host = ap_parts[0];
+        }
+
+        if (ap_parts.size() > 1) {
+            port_str = ap_parts[1];
+        }
+
+        struct addrinfo hints;
+        struct addrinfo *result;
+        memset(&hints, 0, sizeof(struct addrinfo));
+        hints.ai_family = hint_family;
+        hints.ai_socktype = 0;
+
+        int ret = getaddrinfo(host.c_str(), port_str.c_str(), &hints, &result);
+        if (ret != 0) {
+            throw std::runtime_error("getaddrinfo failed for " + host + ": " + gai_strerror(ret));
+        }
+
+        int resolved_family = 0;
+        bool found = false;
+        for (auto rp = result; rp != nullptr; rp = rp->ai_next) {
+            if (hint_family == AF_UNSPEC || rp->ai_family == hint_family) {
+                memcpy(&ss, rp->ai_addr, rp->ai_addrlen);
+                resolved_family = rp->ai_family;
+                found = true;
+                break;
+            }
+        }
+
+        freeaddrinfo(result);
+
+        if (!found) {
+            throw std::runtime_error("could not resolve address for the given family: " + host);
+        }
+        return resolved_family;
+    };
+
+    int src_family = parse_addr_port(parts[0], info.src_addr, family);
+    int dst_family = parse_addr_port(parts[1], info.dst_addr, (family == AF_UNSPEC) ? src_family : family);
+
+    if (src_family != dst_family) {
+        throw std::runtime_error("proxy spec source and destination address families must match");
+    }
+    info.family = src_family;
+
+    return info;
+}
+
+std::vector<char> generate_proxy_v2_header(const ProxyInfo &info, Protocol proto)
+{
+    if (info.family != AF_INET && info.family != AF_INET6) {
+        throw std::runtime_error("unsupported address family for PROXY v2 header");
+    }
+
+    size_t addr_block_size = (info.family == AF_INET) ? 12 : 36;
+    std::vector<char> header;
+    header.reserve(16 + addr_block_size);
+
+    const char signature[] = "\x0D\x0A\x0D\x0A\x00\x0D\x0A\x51\x55\x49\x54\x0A";
+    header.insert(header.end(), signature, signature + 12);
+
+    header.push_back(0x21); // version 2, PROXY command
+
+    uint8_t transport = 0;
+    switch (proto) {
+    case Protocol::UDP:
+        transport = 0x02; // DGRAM
+        break;
+    case Protocol::TCP:
+    case Protocol::DOT:
+#ifdef DOH_ENABLE
+    case Protocol::DOH:
+#endif
+        transport = 0x01; // STREAM
+        break;
+    }
+
+    uint8_t family_proto;
+    if (info.family == AF_INET) {
+        family_proto = 0x10 | transport; // AF_INET
+    } else {
+        family_proto = 0x20 | transport; // AF_INET6
+    }
+    header.push_back(static_cast<char>(family_proto));
+
+    uint16_t addr_len_n = htons(static_cast<uint16_t>(addr_block_size));
+    header.insert(header.end(),
+        reinterpret_cast<const char *>(&addr_len_n),
+        reinterpret_cast<const char *>(&addr_len_n) + 2);
+
+    auto append = [&header](const void *src, size_t len) {
+        auto *p = reinterpret_cast<const char *>(src);
+        header.insert(header.end(), p, p + len);
+    };
+
+    if (info.family == AF_INET) {
+        auto *src_sin = reinterpret_cast<const struct sockaddr_in *>(&info.src_addr);
+        auto *dst_sin = reinterpret_cast<const struct sockaddr_in *>(&info.dst_addr);
+        append(&src_sin->sin_addr, 4);
+        append(&dst_sin->sin_addr, 4);
+        append(&src_sin->sin_port, 2);
+        append(&dst_sin->sin_port, 2);
+    } else {
+        auto *src_sin6 = reinterpret_cast<const struct sockaddr_in6 *>(&info.src_addr);
+        auto *dst_sin6 = reinterpret_cast<const struct sockaddr_in6 *>(&info.dst_addr);
+        append(&src_sin6->sin6_addr, 16);
+        append(&dst_sin6->sin6_addr, 16);
+        append(&src_sin6->sin6_port, 2);
+        append(&dst_sin6->sin6_port, 2);
+    }
+
+    return header;
+}

--- a/flame/proxy.h
+++ b/flame/proxy.h
@@ -1,0 +1,24 @@
+// Copyright 2025 Flamethrower Contributors
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include <sys/socket.h>
+
+#include "protocol.h"
+
+struct ProxyInfo {
+    bool enabled = false;
+    struct sockaddr_storage src_addr{};
+    struct sockaddr_storage dst_addr{};
+    int family{};
+};
+
+// Parse the proxy spec string: SRC_ADDR[#SRC_PORT]-DST_ADDR[#DST_PORT]
+// family can be AF_INET, AF_INET6, or AF_UNSPEC (auto-detect from addresses)
+ProxyInfo parse_proxy_spec(const std::string &spec, int family);
+
+// Generate a PROXY protocol v2 header
+std::vector<char> generate_proxy_v2_header(const ProxyInfo &info, Protocol proto);

--- a/flame/trafgen.cpp
+++ b/flame/trafgen.cpp
@@ -3,11 +3,13 @@
 #include "trafgen.h"
 
 #include <algorithm>
+#include <cstring>
 #include <iostream>
 #include <memory>
 #include <netinet/in.h>
 #include <random>
 
+#include "proxy.h"
 #include "tcp.h"
 #include "tcptlssession.h"
 
@@ -250,6 +252,13 @@ void TrafGen::connect_tcp_events()
 
     // SOCKET: on connect
     _tcp_handle->on<uvw::connect_event>([this](uvw::connect_event &, uvw::tcp_handle &) {
+        // Send PROXY v2 header at TCP level before any session handshake
+        if (!_cached_proxy_header.empty()) {
+            auto data = std::make_unique<char[]>(_cached_proxy_header.size());
+            memcpy(data.get(), _cached_proxy_header.data(), _cached_proxy_header.size());
+            _tcp_handle->write(std::move(data), _cached_proxy_header.size());
+        }
+
         _tcp_session->on_connect_event();
         _metrics->tcp_connection();
 
@@ -312,14 +321,30 @@ void TrafGen::udp_send()
         _free_id_list.pop_back();
         assert(_in_flight.find(id) == _in_flight.end());
         auto qt = _qgen->next_udp(id);
-        _udp_handle->send(_traf_config->next_target().address, std::move(std::get<0>(qt)), std::get<1>(qt));
-        _metrics->send(std::get<1>(qt), 1, _in_flight.size());
+
+        std::unique_ptr<char[]> data_to_send = std::move(std::get<0>(qt));
+        size_t data_len = std::get<1>(qt);
+
+        if (!_cached_proxy_header.empty()) {
+            size_t new_len = _cached_proxy_header.size() + data_len;
+            auto new_data = std::make_unique<char[]>(new_len);
+            memcpy(new_data.get(), _cached_proxy_header.data(), _cached_proxy_header.size());
+            memcpy(new_data.get() + _cached_proxy_header.size(), data_to_send.get(), data_len);
+            data_to_send = std::move(new_data);
+            data_len = new_len;
+        }
+
+        _udp_handle->send(_traf_config->next_target().address, std::move(data_to_send), data_len);
+        _metrics->send(data_len, 1, _in_flight.size());
         _in_flight[id].send_time = std::chrono::high_resolution_clock::now();
     }
 }
 
 void TrafGen::start()
 {
+    if (_traf_config->proxy_info.enabled) {
+        _cached_proxy_header = generate_proxy_v2_header(_traf_config->proxy_info, _traf_config->protocol);
+    }
 
     if (_traf_config->protocol == Protocol::UDP) {
         start_udp();

--- a/flame/trafgen.h
+++ b/flame/trafgen.h
@@ -15,21 +15,14 @@
 
 #include "addr.h"
 #include "metrics.h"
+#include "protocol.h"
+#include "proxy.h"
 #include "query.h"
 #include "target.h"
 #include "tcpsession.h"
 #include "tokenbucket.h"
 
 #include <uvw.hpp>
-
-enum class Protocol {
-    UDP,
-    TCP,
-#ifdef DOH_ENABLE
-    DOH,
-#endif
-    DOT,
-};
 
 struct TrafGenConfig {
     std::vector<Target> target_list;
@@ -40,6 +33,7 @@ struct TrafGenConfig {
     long s_delay{1};
     long batch_count{10};
     Protocol protocol{Protocol::UDP};
+    ProxyInfo proxy_info;
 #ifdef DOH_ENABLE
     HTTPMethod method{HTTPMethod::POST};
 #endif
@@ -75,6 +69,9 @@ class TrafGen {
     std::unordered_map<uint16_t, Query> _in_flight;
     // a randomized list of query ids that are not currently in flight
     std::vector<uint16_t> _free_id_list;
+
+    // cached PROXY v2 header, empty when proxy is disabled
+    std::vector<char> _cached_proxy_header;
 
     bool _started_sending;
     bool _stopping;

--- a/meson.build
+++ b/meson.build
@@ -130,6 +130,9 @@ flame_sources = files(
   'flame/addr.cpp',
   'flame/metrics.cpp',
   'flame/metrics.h',
+  'flame/protocol.h',
+  'flame/proxy.cpp',
+  'flame/proxy.h',
   'flame/query.cpp',
   'flame/query.h',
   'flame/target.h',
@@ -182,3 +185,19 @@ flame = executable(
   include_directories: include_directories('flame'),
   install: true,
 )
+
+# tests
+
+test_proxy_args = []
+if get_option('doh')
+  test_proxy_args += ['-DDOH_ENABLE']
+endif
+
+test_proxy = executable(
+  'test_proxy',
+  files('tests/test_proxy.cpp', 'flame/proxy.cpp', 'flame/utils.cpp'),
+  cpp_args: test_proxy_args,
+  include_directories: include_directories('flame'),
+)
+
+test('proxy_protocol_v2', test_proxy)

--- a/tests/test_proxy.cpp
+++ b/tests/test_proxy.cpp
@@ -1,0 +1,580 @@
+// Copyright 2025 Flamethrower Contributors
+
+#include <cassert>
+#include <cstring>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+
+#include "proxy.h"
+
+static int tests_run = 0;
+static int tests_failed = 0;
+
+#define RUN_TEST(func)                                         \
+    do {                                                       \
+        tests_run++;                                           \
+        std::cout << "  " #func "... ";                        \
+        try {                                                  \
+            func();                                            \
+            std::cout << "PASS" << std::endl;                  \
+        } catch (const std::exception &e) {                    \
+            tests_failed++;                                    \
+            std::cout << "FAIL: " << e.what() << std::endl;    \
+        } catch (...) {                                        \
+            tests_failed++;                                    \
+            std::cout << "FAIL: unknown exception" << std::endl; \
+        }                                                      \
+    } while (0)
+
+#define ASSERT_EQ(a, b)                                            \
+    do {                                                           \
+        if ((a) != (b)) {                                          \
+            throw std::runtime_error(                              \
+                std::string("assertion failed: ") + #a " != " #b); \
+        }                                                          \
+    } while (0)
+
+#define ASSERT_THROW(expr)                                              \
+    do {                                                                \
+        bool caught = false;                                            \
+        try {                                                           \
+            expr;                                                       \
+        } catch (const std::exception &) {                              \
+            caught = true;                                              \
+        }                                                               \
+        if (!caught)                                                    \
+            throw std::runtime_error("expected exception from: " #expr); \
+    } while (0)
+
+static const unsigned char PPV2_SIGNATURE[] = {
+    0x0D, 0x0A, 0x0D, 0x0A, 0x00, 0x0D, 0x0A, 0x51, 0x55, 0x49, 0x54, 0x0A};
+
+static ProxyInfo make_ipv4_info(const char *src_ip, uint16_t src_port,
+    const char *dst_ip, uint16_t dst_port)
+{
+    ProxyInfo info{};
+    info.enabled = true;
+    info.family = AF_INET;
+
+    auto *src = reinterpret_cast<sockaddr_in *>(&info.src_addr);
+    src->sin_family = AF_INET;
+    inet_pton(AF_INET, src_ip, &src->sin_addr);
+    src->sin_port = htons(src_port);
+
+    auto *dst = reinterpret_cast<sockaddr_in *>(&info.dst_addr);
+    dst->sin_family = AF_INET;
+    inet_pton(AF_INET, dst_ip, &dst->sin_addr);
+    dst->sin_port = htons(dst_port);
+
+    return info;
+}
+
+static ProxyInfo make_ipv6_info(const char *src_ip, uint16_t src_port,
+    const char *dst_ip, uint16_t dst_port)
+{
+    ProxyInfo info{};
+    info.enabled = true;
+    info.family = AF_INET6;
+
+    auto *src = reinterpret_cast<sockaddr_in6 *>(&info.src_addr);
+    src->sin6_family = AF_INET6;
+    inet_pton(AF_INET6, src_ip, &src->sin6_addr);
+    src->sin6_port = htons(src_port);
+
+    auto *dst = reinterpret_cast<sockaddr_in6 *>(&info.dst_addr);
+    dst->sin6_family = AF_INET6;
+    inet_pton(AF_INET6, dst_ip, &dst->sin6_addr);
+    dst->sin6_port = htons(dst_port);
+
+    return info;
+}
+
+// ===== generate_proxy_v2_header: signature and version =====
+
+void test_header_signature()
+{
+    auto info = make_ipv4_info("192.168.1.1", 12345, "10.0.0.1", 53);
+    auto header = generate_proxy_v2_header(info, Protocol::UDP);
+
+    ASSERT_EQ(header.size() >= 16, true);
+    ASSERT_EQ(memcmp(header.data(), PPV2_SIGNATURE, 12), 0);
+}
+
+void test_header_version_command()
+{
+    auto info = make_ipv4_info("192.168.1.1", 12345, "10.0.0.1", 53);
+    auto header = generate_proxy_v2_header(info, Protocol::UDP);
+
+    // version 2, PROXY command -> 0x21
+    ASSERT_EQ((unsigned char)header[12], 0x21);
+}
+
+// ===== generate_proxy_v2_header: family/protocol byte =====
+
+void test_ipv4_udp_family_protocol()
+{
+    auto info = make_ipv4_info("1.2.3.4", 1000, "5.6.7.8", 53);
+    auto header = generate_proxy_v2_header(info, Protocol::UDP);
+
+    // AF_INET=0x1, DGRAM=0x2 -> 0x12
+    ASSERT_EQ((unsigned char)header[13], 0x12);
+}
+
+void test_ipv4_tcp_family_protocol()
+{
+    auto info = make_ipv4_info("1.2.3.4", 1000, "5.6.7.8", 53);
+    auto header = generate_proxy_v2_header(info, Protocol::TCP);
+
+    // AF_INET=0x1, STREAM=0x1 -> 0x11
+    ASSERT_EQ((unsigned char)header[13], 0x11);
+}
+
+void test_ipv4_dot_family_protocol()
+{
+    auto info = make_ipv4_info("1.2.3.4", 1000, "5.6.7.8", 853);
+    auto header = generate_proxy_v2_header(info, Protocol::DOT);
+
+    // DoT uses TCP -> 0x11
+    ASSERT_EQ((unsigned char)header[13], 0x11);
+}
+
+#ifdef DOH_ENABLE
+void test_ipv4_doh_family_protocol()
+{
+    auto info = make_ipv4_info("1.2.3.4", 1000, "5.6.7.8", 443);
+    auto header = generate_proxy_v2_header(info, Protocol::DOH);
+
+    // DoH uses TCP -> 0x11
+    ASSERT_EQ((unsigned char)header[13], 0x11);
+}
+#endif
+
+void test_ipv6_udp_family_protocol()
+{
+    auto info = make_ipv6_info("2001:db8::1", 1000, "2001:db8::2", 53);
+    auto header = generate_proxy_v2_header(info, Protocol::UDP);
+
+    // AF_INET6=0x2, DGRAM=0x2 -> 0x22
+    ASSERT_EQ((unsigned char)header[13], 0x22);
+}
+
+void test_ipv6_tcp_family_protocol()
+{
+    auto info = make_ipv6_info("2001:db8::1", 1000, "2001:db8::2", 53);
+    auto header = generate_proxy_v2_header(info, Protocol::TCP);
+
+    // AF_INET6=0x2, STREAM=0x1 -> 0x21
+    ASSERT_EQ((unsigned char)header[13], 0x21);
+}
+
+void test_ipv6_dot_family_protocol()
+{
+    auto info = make_ipv6_info("::1", 1000, "::1", 853);
+    auto header = generate_proxy_v2_header(info, Protocol::DOT);
+
+    // DoT uses TCP -> 0x21
+    ASSERT_EQ((unsigned char)header[13], 0x21);
+}
+
+#ifdef DOH_ENABLE
+void test_ipv6_doh_family_protocol()
+{
+    auto info = make_ipv6_info("::1", 1000, "::1", 443);
+    auto header = generate_proxy_v2_header(info, Protocol::DOH);
+
+    // DoH uses TCP -> 0x21
+    ASSERT_EQ((unsigned char)header[13], 0x21);
+}
+#endif
+
+// ===== generate_proxy_v2_header: address length and total size =====
+
+void test_ipv4_address_length()
+{
+    auto info = make_ipv4_info("1.2.3.4", 1000, "5.6.7.8", 53);
+    auto header = generate_proxy_v2_header(info, Protocol::UDP);
+
+    // IPv4: 4 + 4 + 2 + 2 = 12
+    uint16_t addr_len;
+    memcpy(&addr_len, &header[14], 2);
+    ASSERT_EQ(ntohs(addr_len), 12);
+}
+
+void test_ipv4_total_size()
+{
+    auto info = make_ipv4_info("1.2.3.4", 1000, "5.6.7.8", 53);
+    auto header = generate_proxy_v2_header(info, Protocol::TCP);
+
+    // 16 fixed + 12 addresses = 28
+    ASSERT_EQ(header.size(), (size_t)28);
+}
+
+void test_ipv6_address_length()
+{
+    auto info = make_ipv6_info("2001:db8::1", 1000, "2001:db8::2", 53);
+    auto header = generate_proxy_v2_header(info, Protocol::TCP);
+
+    // IPv6: 16 + 16 + 2 + 2 = 36
+    uint16_t addr_len;
+    memcpy(&addr_len, &header[14], 2);
+    ASSERT_EQ(ntohs(addr_len), 36);
+}
+
+void test_ipv6_total_size()
+{
+    auto info = make_ipv6_info("2001:db8::1", 1000, "2001:db8::2", 53);
+    auto header = generate_proxy_v2_header(info, Protocol::TCP);
+
+    // 16 fixed + 36 addresses = 52
+    ASSERT_EQ(header.size(), (size_t)52);
+}
+
+// ===== generate_proxy_v2_header: address and port encoding =====
+
+void test_ipv4_addresses_and_ports()
+{
+    auto info = make_ipv4_info("192.168.1.100", 8080, "10.20.30.40", 53);
+    auto header = generate_proxy_v2_header(info, Protocol::TCP);
+
+    // Source IPv4 at offset 16
+    struct in_addr src_addr, dst_addr;
+    memcpy(&src_addr, &header[16], 4);
+    memcpy(&dst_addr, &header[20], 4);
+
+    char src_str[INET_ADDRSTRLEN], dst_str[INET_ADDRSTRLEN];
+    inet_ntop(AF_INET, &src_addr, src_str, sizeof(src_str));
+    inet_ntop(AF_INET, &dst_addr, dst_str, sizeof(dst_str));
+
+    ASSERT_EQ(std::string(src_str), std::string("192.168.1.100"));
+    ASSERT_EQ(std::string(dst_str), std::string("10.20.30.40"));
+
+    // Source port at offset 24, dest port at offset 26
+    uint16_t src_port, dst_port;
+    memcpy(&src_port, &header[24], 2);
+    memcpy(&dst_port, &header[26], 2);
+    ASSERT_EQ(ntohs(src_port), 8080);
+    ASSERT_EQ(ntohs(dst_port), 53);
+}
+
+void test_ipv6_addresses_and_ports()
+{
+    auto info = make_ipv6_info("2001:db8::1", 9999, "fe80::42", 853);
+    auto header = generate_proxy_v2_header(info, Protocol::DOT);
+
+    // Source IPv6 at offset 16 (16 bytes), dest at offset 32
+    struct in6_addr src_addr, dst_addr;
+    memcpy(&src_addr, &header[16], 16);
+    memcpy(&dst_addr, &header[32], 16);
+
+    char src_str[INET6_ADDRSTRLEN], dst_str[INET6_ADDRSTRLEN];
+    inet_ntop(AF_INET6, &src_addr, src_str, sizeof(src_str));
+    inet_ntop(AF_INET6, &dst_addr, dst_str, sizeof(dst_str));
+
+    ASSERT_EQ(std::string(src_str), std::string("2001:db8::1"));
+    ASSERT_EQ(std::string(dst_str), std::string("fe80::42"));
+
+    // Source port at offset 48, dest port at offset 50
+    uint16_t src_port, dst_port;
+    memcpy(&src_port, &header[48], 2);
+    memcpy(&dst_port, &header[50], 2);
+    ASSERT_EQ(ntohs(src_port), 9999);
+    ASSERT_EQ(ntohs(dst_port), 853);
+}
+
+// ===== generate_proxy_v2_header: error cases =====
+
+void test_generate_invalid_family()
+{
+    ProxyInfo info{};
+    info.enabled = true;
+    info.family = AF_UNSPEC;
+    ASSERT_THROW(generate_proxy_v2_header(info, Protocol::UDP));
+}
+
+// ===== parse_proxy_spec =====
+
+void test_parse_ipv4_with_ports()
+{
+    auto info = parse_proxy_spec("127.0.0.1#8080-127.0.0.2#53", AF_INET);
+
+    ASSERT_EQ(info.enabled, true);
+    ASSERT_EQ(info.family, AF_INET);
+
+    auto *src = reinterpret_cast<const sockaddr_in *>(&info.src_addr);
+    auto *dst = reinterpret_cast<const sockaddr_in *>(&info.dst_addr);
+
+    char src_str[INET_ADDRSTRLEN], dst_str[INET_ADDRSTRLEN];
+    inet_ntop(AF_INET, &src->sin_addr, src_str, sizeof(src_str));
+    inet_ntop(AF_INET, &dst->sin_addr, dst_str, sizeof(dst_str));
+
+    ASSERT_EQ(std::string(src_str), std::string("127.0.0.1"));
+    ASSERT_EQ(std::string(dst_str), std::string("127.0.0.2"));
+    ASSERT_EQ(ntohs(src->sin_port), 8080);
+    ASSERT_EQ(ntohs(dst->sin_port), 53);
+}
+
+void test_parse_ipv4_without_ports()
+{
+    auto info = parse_proxy_spec("10.0.0.1-10.0.0.2", AF_INET);
+
+    ASSERT_EQ(info.enabled, true);
+    ASSERT_EQ(info.family, AF_INET);
+
+    auto *src = reinterpret_cast<const sockaddr_in *>(&info.src_addr);
+    auto *dst = reinterpret_cast<const sockaddr_in *>(&info.dst_addr);
+
+    char src_str[INET_ADDRSTRLEN], dst_str[INET_ADDRSTRLEN];
+    inet_ntop(AF_INET, &src->sin_addr, src_str, sizeof(src_str));
+    inet_ntop(AF_INET, &dst->sin_addr, dst_str, sizeof(dst_str));
+
+    ASSERT_EQ(std::string(src_str), std::string("10.0.0.1"));
+    ASSERT_EQ(std::string(dst_str), std::string("10.0.0.2"));
+    ASSERT_EQ(ntohs(src->sin_port), 0);
+    ASSERT_EQ(ntohs(dst->sin_port), 0);
+}
+
+void test_parse_ipv6_with_ports()
+{
+    auto info = parse_proxy_spec("[::1]#8080-[::1]#53", AF_INET6);
+
+    ASSERT_EQ(info.enabled, true);
+    ASSERT_EQ(info.family, AF_INET6);
+
+    auto *src = reinterpret_cast<const sockaddr_in6 *>(&info.src_addr);
+    auto *dst = reinterpret_cast<const sockaddr_in6 *>(&info.dst_addr);
+
+    char src_str[INET6_ADDRSTRLEN], dst_str[INET6_ADDRSTRLEN];
+    inet_ntop(AF_INET6, &src->sin6_addr, src_str, sizeof(src_str));
+    inet_ntop(AF_INET6, &dst->sin6_addr, dst_str, sizeof(dst_str));
+
+    ASSERT_EQ(std::string(src_str), std::string("::1"));
+    ASSERT_EQ(std::string(dst_str), std::string("::1"));
+    ASSERT_EQ(ntohs(src->sin6_port), 8080);
+    ASSERT_EQ(ntohs(dst->sin6_port), 53);
+}
+
+void test_parse_ipv6_without_ports()
+{
+    auto info = parse_proxy_spec("[::1]-[::1]", AF_INET6);
+
+    ASSERT_EQ(info.enabled, true);
+    ASSERT_EQ(info.family, AF_INET6);
+
+    auto *src = reinterpret_cast<const sockaddr_in6 *>(&info.src_addr);
+    auto *dst = reinterpret_cast<const sockaddr_in6 *>(&info.dst_addr);
+
+    ASSERT_EQ(ntohs(src->sin6_port), 0);
+    ASSERT_EQ(ntohs(dst->sin6_port), 0);
+}
+
+// ===== parse_proxy_spec: auto-detect family =====
+
+void test_parse_auto_detect_ipv4()
+{
+    auto info = parse_proxy_spec("127.0.0.1#80-127.0.0.2#53", AF_UNSPEC);
+
+    ASSERT_EQ(info.enabled, true);
+    ASSERT_EQ(info.family, AF_INET);
+
+    auto *src = reinterpret_cast<const sockaddr_in *>(&info.src_addr);
+    auto *dst = reinterpret_cast<const sockaddr_in *>(&info.dst_addr);
+
+    char src_str[INET_ADDRSTRLEN], dst_str[INET_ADDRSTRLEN];
+    inet_ntop(AF_INET, &src->sin_addr, src_str, sizeof(src_str));
+    inet_ntop(AF_INET, &dst->sin_addr, dst_str, sizeof(dst_str));
+
+    ASSERT_EQ(std::string(src_str), std::string("127.0.0.1"));
+    ASSERT_EQ(std::string(dst_str), std::string("127.0.0.2"));
+    ASSERT_EQ(ntohs(src->sin_port), 80);
+    ASSERT_EQ(ntohs(dst->sin_port), 53);
+}
+
+void test_parse_auto_detect_ipv6()
+{
+    auto info = parse_proxy_spec("[::1]#80-[::1]#53", AF_UNSPEC);
+
+    ASSERT_EQ(info.enabled, true);
+    ASSERT_EQ(info.family, AF_INET6);
+
+    auto *src = reinterpret_cast<const sockaddr_in6 *>(&info.src_addr);
+    auto *dst = reinterpret_cast<const sockaddr_in6 *>(&info.dst_addr);
+
+    ASSERT_EQ(ntohs(src->sin6_port), 80);
+    ASSERT_EQ(ntohs(dst->sin6_port), 53);
+}
+
+// ===== parse_proxy_spec: family mismatch =====
+
+void test_parse_family_mismatch_v6_as_v4()
+{
+    ASSERT_THROW(parse_proxy_spec("[::1]-[::1]", AF_INET));
+}
+
+// ===== parse_proxy_spec: port boundaries =====
+
+void test_parse_port_65535()
+{
+    auto info = parse_proxy_spec("127.0.0.1#65535-127.0.0.2#65535", AF_INET);
+    auto *src = reinterpret_cast<const sockaddr_in *>(&info.src_addr);
+    auto *dst = reinterpret_cast<const sockaddr_in *>(&info.dst_addr);
+    ASSERT_EQ(ntohs(src->sin_port), 65535);
+    ASSERT_EQ(ntohs(dst->sin_port), 65535);
+}
+
+void test_parse_port_zero_explicit()
+{
+    auto info = parse_proxy_spec("127.0.0.1#0-127.0.0.2#0", AF_INET);
+    auto *src = reinterpret_cast<const sockaddr_in *>(&info.src_addr);
+    auto *dst = reinterpret_cast<const sockaddr_in *>(&info.dst_addr);
+    ASSERT_EQ(ntohs(src->sin_port), 0);
+    ASSERT_EQ(ntohs(dst->sin_port), 0);
+}
+
+// ===== parse_proxy_spec: asymmetric ports =====
+
+void test_parse_asymmetric_ports()
+{
+    auto info = parse_proxy_spec("127.0.0.1-127.0.0.2#53", AF_INET);
+    auto *src = reinterpret_cast<const sockaddr_in *>(&info.src_addr);
+    auto *dst = reinterpret_cast<const sockaddr_in *>(&info.dst_addr);
+    ASSERT_EQ(ntohs(src->sin_port), 0);
+    ASSERT_EQ(ntohs(dst->sin_port), 53);
+}
+
+// ===== parse_proxy_spec: roundtrip through header generation =====
+
+void test_parse_roundtrip_ipv4()
+{
+    auto info = parse_proxy_spec("192.168.0.1#1234-10.0.0.1#5678", AF_INET);
+    auto header = generate_proxy_v2_header(info, Protocol::TCP);
+
+    ASSERT_EQ(header.size(), (size_t)28);
+    ASSERT_EQ((unsigned char)header[13], 0x11); // TCPv4
+
+    struct in_addr src_addr, dst_addr;
+    memcpy(&src_addr, &header[16], 4);
+    memcpy(&dst_addr, &header[20], 4);
+    char src_str[INET_ADDRSTRLEN], dst_str[INET_ADDRSTRLEN];
+    inet_ntop(AF_INET, &src_addr, src_str, sizeof(src_str));
+    inet_ntop(AF_INET, &dst_addr, dst_str, sizeof(dst_str));
+    ASSERT_EQ(std::string(src_str), std::string("192.168.0.1"));
+    ASSERT_EQ(std::string(dst_str), std::string("10.0.0.1"));
+
+    uint16_t src_port, dst_port;
+    memcpy(&src_port, &header[24], 2);
+    memcpy(&dst_port, &header[26], 2);
+    ASSERT_EQ(ntohs(src_port), 1234);
+    ASSERT_EQ(ntohs(dst_port), 5678);
+}
+
+void test_parse_roundtrip_ipv6()
+{
+    auto info = parse_proxy_spec("[::1]#4321-[::1]#8765", AF_INET6);
+    auto header = generate_proxy_v2_header(info, Protocol::UDP);
+
+    ASSERT_EQ(header.size(), (size_t)52);
+    ASSERT_EQ((unsigned char)header[13], 0x22); // UDPv6
+
+    struct in6_addr src_addr, dst_addr;
+    memcpy(&src_addr, &header[16], 16);
+    memcpy(&dst_addr, &header[32], 16);
+    char src_str[INET6_ADDRSTRLEN], dst_str[INET6_ADDRSTRLEN];
+    inet_ntop(AF_INET6, &src_addr, src_str, sizeof(src_str));
+    inet_ntop(AF_INET6, &dst_addr, dst_str, sizeof(dst_str));
+    ASSERT_EQ(std::string(src_str), std::string("::1"));
+    ASSERT_EQ(std::string(dst_str), std::string("::1"));
+
+    uint16_t src_port, dst_port;
+    memcpy(&src_port, &header[48], 2);
+    memcpy(&dst_port, &header[50], 2);
+    ASSERT_EQ(ntohs(src_port), 4321);
+    ASSERT_EQ(ntohs(dst_port), 8765);
+}
+
+// ===== parse_proxy_spec: error cases =====
+
+void test_parse_invalid_no_dash()
+{
+    ASSERT_THROW(parse_proxy_spec("127.0.0.1", AF_INET));
+}
+
+void test_parse_invalid_empty()
+{
+    ASSERT_THROW(parse_proxy_spec("", AF_INET));
+}
+
+void test_parse_invalid_address()
+{
+    ASSERT_THROW(parse_proxy_spec("not_valid-also_not_valid", AF_INET));
+}
+
+void test_parse_invalid_too_many_parts()
+{
+    ASSERT_THROW(parse_proxy_spec("1.2.3.4-5.6.7.8-9.10.11.12", AF_INET));
+}
+
+// ===== ProxyInfo defaults =====
+
+void test_default_proxy_info()
+{
+    ProxyInfo info{};
+    ASSERT_EQ(info.enabled, false);
+    ASSERT_EQ(info.family, 0);
+}
+
+int main()
+{
+    std::cout << "=== generate_proxy_v2_header ===" << std::endl;
+    RUN_TEST(test_header_signature);
+    RUN_TEST(test_header_version_command);
+    RUN_TEST(test_ipv4_udp_family_protocol);
+    RUN_TEST(test_ipv4_tcp_family_protocol);
+    RUN_TEST(test_ipv4_dot_family_protocol);
+#ifdef DOH_ENABLE
+    RUN_TEST(test_ipv4_doh_family_protocol);
+#endif
+    RUN_TEST(test_ipv6_udp_family_protocol);
+    RUN_TEST(test_ipv6_tcp_family_protocol);
+    RUN_TEST(test_ipv6_dot_family_protocol);
+#ifdef DOH_ENABLE
+    RUN_TEST(test_ipv6_doh_family_protocol);
+#endif
+    RUN_TEST(test_ipv4_address_length);
+    RUN_TEST(test_ipv4_total_size);
+    RUN_TEST(test_ipv6_address_length);
+    RUN_TEST(test_ipv6_total_size);
+    RUN_TEST(test_ipv4_addresses_and_ports);
+    RUN_TEST(test_ipv6_addresses_and_ports);
+    RUN_TEST(test_generate_invalid_family);
+
+    std::cout << std::endl
+              << "=== parse_proxy_spec ===" << std::endl;
+    RUN_TEST(test_parse_ipv4_with_ports);
+    RUN_TEST(test_parse_ipv4_without_ports);
+    RUN_TEST(test_parse_ipv6_with_ports);
+    RUN_TEST(test_parse_ipv6_without_ports);
+    RUN_TEST(test_parse_auto_detect_ipv4);
+    RUN_TEST(test_parse_auto_detect_ipv6);
+    RUN_TEST(test_parse_family_mismatch_v6_as_v4);
+    RUN_TEST(test_parse_port_65535);
+    RUN_TEST(test_parse_port_zero_explicit);
+    RUN_TEST(test_parse_asymmetric_ports);
+    RUN_TEST(test_parse_roundtrip_ipv4);
+    RUN_TEST(test_parse_roundtrip_ipv6);
+    RUN_TEST(test_parse_invalid_no_dash);
+    RUN_TEST(test_parse_invalid_empty);
+    RUN_TEST(test_parse_invalid_address);
+    RUN_TEST(test_parse_invalid_too_many_parts);
+    RUN_TEST(test_default_proxy_info);
+
+    std::cout << std::endl
+              << tests_run << " tests run, "
+              << (tests_run - tests_failed) << " passed, "
+              << tests_failed << " failed" << std::endl;
+
+    return tests_failed ? 1 : 0;
+}


### PR DESCRIPTION
## Summary
- Add `--proxy SRC_ADDR[#SRC_PORT]-DST_ADDR[#DST_PORT]` CLI option to prepend PROXY protocol v2 headers to DNS queries
- Supports IPv4/IPv6, UDP (per-datagram), TCP/DoT/DoH (per-connection), with address family auto-detection
- Extract `Protocol` enum into `protocol.h` to break circular dependency with new `proxy.h`/`proxy.cpp` module
- Cache the generated PPv2 header in `TrafGen` to avoid per-packet reconstruction
- Add comprehensive test suite (30+ tests) covering all protocol/family combinations, address encoding, port boundaries, round-trips, and error cases
- Update README with usage examples and detailed feature documentation

## Test plan
- [x] `meson test` passes (all 30+ proxy protocol tests)
- [x] `ninja` builds cleanly with `warning_level=3`
- [x] Manual test: `flame --proxy 127.0.0.1#4321-127.0.0.2#53 <target>` over UDP
- [x] Manual test: `flame -P tcp --proxy 127.0.0.1#4321-127.0.0.2#53 <target>` over TCP
- [x] Manual test: IPv6 variant with `[::1]` bracket syntax
- [x] Verify PPv2 header with packet capture — signature, ver/cmd, family/proto, addresses, ports all byte-correct

## Testing notes

### UDP + IPv4 proxy
```
$ ./build/flame --proxy 127.0.0.1#4321-127.0.0.2#53 -l 2 -c 1 -q 1 -v 2 8.8.8.8
PROXY v2 header enabled
avg pkt: 65 bytes  (28 PPv2 IPv4 header + 37 DNS query)
```

### TCP + IPv4 proxy
```
$ ./build/flame --proxy 127.0.0.1#4321-127.0.0.2#53 -P tcp -l 2 -c 1 -q 1 -v 2 8.8.8.8
PROXY v2 header enabled
tcp conn.: 1  (header sent once at connection establishment)
```

### UDP + IPv6 proxy
```
$ ./build/flame -F inet6 --proxy '[::1]#4321-[::1]#53' -l 2 -c 1 -q 1 -v 2 '[2001:4860:4860::8888]'
PROXY v2 header enabled
avg pkt: 89 bytes  (52 PPv2 IPv6 header + 37 DNS query)
```

### Wire capture verification
Captured a UDP packet sent to a local listener and verified every field:
```
PPv2 signature valid: True
Ver/cmd byte: 0x21 (version 2, PROXY command)
Family/proto byte: 0x12 (IPv4 + DGRAM)
Address length: 12
Src: 192.168.1.100:4321
Dst: 10.0.0.1:53
DNS payload starts at byte 28, remaining 37 bytes
```

## Design notes
- PPv2 header is generated once at `TrafGen::start()` and cached in `_cached_proxy_header` to avoid per-packet allocation overhead.
- For TCP/DoT/DoH, the header is written on the raw TCP stream before `on_connect_event()` (TLS handshake). libuv guarantees FIFO write ordering, so the header precedes the ClientHello.
- The `--proxy` flag uses `AF_UNSPEC` for address family auto-detection, since the PPv2 header describes the original client's addresses, not the flamethrower transport.